### PR TITLE
[BE] API 공통 응답 객체 정의

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,4 @@ gradle-app.setting
 
 ### BACKEND
 backend/src/main/resources/application.yml
+**/.idea

--- a/backend/src/main/java/com/woowacourse/momo/controller/MomoApiResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/MomoApiResponse.java
@@ -1,0 +1,4 @@
+package com.woowacourse.momo.controller;
+
+public record MomoApiResponse<T>(T data) {
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #10 

## 작업 내용

API 응답 결과를 추상화하여 공통으로 내려 줄 응답 객체를 정의했습니다.

## 특이 사항

타입 변수 `T`에 `List<Object>` 형태의 타입 전달도 가능하므로, `SingleResponse`와 `ListResponse` 객체를 분리하지 않고 하나로 통합했습니다.

일반적으로 공통 응답 객체에는 상태코드나 메시지 등을 정의하는 경우도 있지만, 현재 단계에서는 불필요하다고 판단하여 우선 `data` 필드만 정의했습니다.

## 리뷰 요구사항 (선택)

전역 `.gitignore`에 추가해야 하는 사항이 있어 수정해서 그런지 프론트 팀원분들도 같이 CODEOWNER가 적용돼서 리뷰어로 고정되네요🥲 백엔드 분들만 리뷰 주시면 될 것 같습니다!
