### PR TITLE
[BE] 미팅 기본 정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -1,0 +1,22 @@
+package com.woowacourse.momo.controller.meeting;
+
+import com.woowacourse.momo.controller.MomoApiResponse;
+import com.woowacourse.momo.domain.meeting.dto.MeetingResponse;
+import com.woowacourse.momo.service.meeting.MeetingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @GetMapping("/api/v1/meeting/{uuid}")
+    public MomoApiResponse<MeetingResponse> find(@PathVariable String uuid) {
+        MeetingResponse meetingResponse = meetingService.findByUUID(uuid);
+        return new MomoApiResponse<>(meetingResponse);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -1,7 +1,7 @@
 package com.woowacourse.momo.controller.meeting;
 
 import com.woowacourse.momo.controller.MomoApiResponse;
-import com.woowacourse.momo.domain.meeting.dto.MeetingResponse;
+import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.service.meeting.MeetingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDateRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDateRepository.java
@@ -3,9 +3,12 @@ package com.woowacourse.momo.domain.availabledate;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
 
     Optional<AvailableDate> findByMeetingAndDate(Meeting meeting, LocalDate date);
+
+    List<AvailableDate> findAllByMeeting(Meeting meeting);
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDateRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDateRepository.java
@@ -2,8 +2,8 @@ package com.woowacourse.momo.domain.availabledate;
 
 import com.woowacourse.momo.domain.meeting.Meeting;
 import java.time.LocalDate;
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {

--- a/backend/src/main/java/com/woowacourse/momo/domain/meeting/MeetingRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/meeting/MeetingRepository.java
@@ -1,6 +1,9 @@
 package com.woowacourse.momo.domain.meeting;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    Optional<Meeting> findByUuid(String uuid);
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/meeting/dto/MeetingResponse.java
@@ -1,0 +1,28 @@
+package com.woowacourse.momo.domain.meeting.dto;
+
+import com.woowacourse.momo.domain.meeting.Meeting;
+import com.woowacourse.momo.domain.schedule.dto.ScheduleTimeResponse;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record MeetingResponse(
+        String meetingName,
+        LocalTime startTime,
+        LocalTime endTime,
+        List<LocalDate> availableDates,
+        List<ScheduleTimeResponse> schedules
+) {
+
+    public static MeetingResponse from(
+            Meeting meeting, List<LocalDate> availableDates, List<ScheduleTimeResponse> schedules
+    ) {
+        return new MeetingResponse(
+                meeting.getName(),
+                meeting.getStartTime().getTime(),
+                meeting.getEndTime().getTime(),
+                availableDates,
+                schedules
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/domain/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/schedule/ScheduleRepository.java
@@ -1,10 +1,13 @@
 package com.woowacourse.momo.domain.schedule;
 
-import com.woowacourse.momo.domain.guest.Guest;
 import com.woowacourse.momo.domain.meeting.Meeting;
+import java.util.List;
+import com.woowacourse.momo.domain.guest.Guest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    List<Schedule> findAllByMeeting(Meeting meeting);
 
     void deleteAllByMeetingAndGuest(Meeting meeting, Guest guest);
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/schedule/ScheduleRepository.java
@@ -1,8 +1,8 @@
 package com.woowacourse.momo.domain.schedule;
 
+import com.woowacourse.momo.domain.guest.Guest;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import java.util.List;
-import com.woowacourse.momo.domain.guest.Guest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {

--- a/backend/src/main/java/com/woowacourse/momo/domain/schedule/dto/ScheduleTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/schedule/dto/ScheduleTimeResponse.java
@@ -1,0 +1,32 @@
+package com.woowacourse.momo.domain.schedule.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.woowacourse.momo.domain.schedule.Schedule;
+import com.woowacourse.momo.domain.timeslot.Timeslot;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+// TODO: 레코드 명 고민
+public record ScheduleTimeResponse(
+        LocalDate date,
+        @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") List<LocalTime> times
+) {
+
+    // TODO: 디미터 법칙 지키기
+    public static ScheduleTimeResponse from(List<Schedule> schedules) {
+
+        LocalDate date = schedules.stream()
+                .map(schedule -> schedule.getAvailableDate().getDate())
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+
+        List<LocalTime> localTimes = schedules.stream()
+                .map(Schedule::getTimeslot)
+                .map(Timeslot::getTime)
+                .sorted()
+                .toList();
+        return new ScheduleTimeResponse(date, localTimes);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/domain/schedule/dto/ScheduleTimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/schedule/dto/ScheduleTimeResponse.java
@@ -8,13 +8,11 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-// TODO: 레코드 명 고민
 public record ScheduleTimeResponse(
         LocalDate date,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") List<LocalTime> times
 ) {
 
-    // TODO: 디미터 법칙 지키기
     public static ScheduleTimeResponse from(List<Schedule> schedules) {
 
         LocalDate date = schedules.stream()

--- a/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
@@ -2,7 +2,9 @@ package com.woowacourse.momo.domain.timeslot;
 
 import java.time.LocalTime;
 import java.util.Arrays;
+import lombok.Getter;
 
+@Getter
 public enum Timeslot {
 
     TIME_0000(LocalTime.of(0, 0)),
@@ -65,9 +67,5 @@ public enum Timeslot {
                 .filter(timeslot -> timeslot.time.equals(localTime))
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 타임슬롯입니다."));
-    }
-
-    public LocalTime getTime() {
-        return time;
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
@@ -66,4 +66,8 @@ public enum Timeslot {
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 타임슬롯입니다."));
     }
+
+    public LocalTime getTime() {
+        return time;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -4,7 +4,7 @@ import com.woowacourse.momo.domain.availabledate.AvailableDate;
 import com.woowacourse.momo.domain.availabledate.AvailableDateRepository;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.meeting.MeetingRepository;
-import com.woowacourse.momo.domain.meeting.dto.MeetingResponse;
+import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.schedule.dto.ScheduleTimeResponse;

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -28,7 +28,6 @@ public class MeetingService {
 
     @Transactional(readOnly = true)
     public MeetingResponse findByUUID(String uuid) {
-        // TODO: 커스텀 예외 수정
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(IllegalArgumentException::new);
 

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -1,0 +1,51 @@
+package com.woowacourse.momo.service.meeting;
+
+import com.woowacourse.momo.domain.availabledate.AvailableDate;
+import com.woowacourse.momo.domain.availabledate.AvailableDateRepository;
+import com.woowacourse.momo.domain.meeting.Meeting;
+import com.woowacourse.momo.domain.meeting.MeetingRepository;
+import com.woowacourse.momo.domain.meeting.dto.MeetingResponse;
+import com.woowacourse.momo.domain.schedule.Schedule;
+import com.woowacourse.momo.domain.schedule.ScheduleRepository;
+import com.woowacourse.momo.domain.schedule.dto.ScheduleTimeResponse;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingService {
+
+    private final MeetingRepository meetingRepository;
+    private final AvailableDateRepository availableDateRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Transactional(readOnly = true)
+    public MeetingResponse findByUUID(String uuid) {
+        // TODO: 커스텀 예외 수정
+        Meeting meeting = meetingRepository.findByUuid(uuid)
+                .orElseThrow(IllegalArgumentException::new);
+
+        List<AvailableDate> availableDates = availableDateRepository.findAllByMeeting(meeting);
+        List<LocalDate> dates = availableDates.stream()
+                .map(AvailableDate::getDate)
+                .toList();
+
+        List<Schedule> schedules = scheduleRepository.findAllByMeeting(meeting);
+        Map<AvailableDate, List<Schedule>> collected = schedules.stream()
+                .collect(Collectors.groupingBy(Schedule::getAvailableDate));
+        List<ScheduleTimeResponse> list = collected.entrySet().stream()
+                .sorted(Comparator.comparing(a -> a.getKey().getDate()))
+                .map(Entry::getValue)
+                .map(ScheduleTimeResponse::from)
+                .toList();
+
+        return MeetingResponse.from(meeting, dates, list);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingResponse.java
@@ -1,5 +1,7 @@
-package com.woowacourse.momo.domain.meeting.dto;
+package com.woowacourse.momo.service.meeting.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.schedule.dto.ScheduleTimeResponse;
 import java.time.LocalDate;

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingResponse.java
@@ -10,8 +10,8 @@ import java.util.List;
 
 public record MeetingResponse(
         String meetingName,
-        LocalTime startTime,
-        LocalTime endTime,
+        @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") LocalTime startTime,
+        @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") LocalTime endTime,
         List<LocalDate> availableDates,
         List<ScheduleTimeResponse> schedules
 ) {

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -7,7 +7,7 @@ import com.woowacourse.momo.domain.guest.GuestName;
 import com.woowacourse.momo.domain.guest.GuestRepository;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.meeting.MeetingRepository;
-import com.woowacourse.momo.domain.meeting.dto.MeetingResponse;
+import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -1,0 +1,83 @@
+package com.woowacourse.momo.service.meeting;
+
+import com.woowacourse.momo.domain.availabledate.AvailableDate;
+import com.woowacourse.momo.domain.availabledate.AvailableDateRepository;
+import com.woowacourse.momo.domain.guest.Guest;
+import com.woowacourse.momo.domain.guest.GuestName;
+import com.woowacourse.momo.domain.guest.GuestRepository;
+import com.woowacourse.momo.domain.meeting.Meeting;
+import com.woowacourse.momo.domain.meeting.MeetingRepository;
+import com.woowacourse.momo.domain.meeting.dto.MeetingResponse;
+import com.woowacourse.momo.domain.schedule.Schedule;
+import com.woowacourse.momo.domain.schedule.ScheduleRepository;
+import com.woowacourse.momo.domain.timeslot.Timeslot;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class MeetingServiceTest {
+
+    @Autowired
+    private MeetingService meetingService;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private AvailableDateRepository availableDateRepository;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private GuestRepository guestRepository;
+
+    @BeforeEach
+    void setup() {
+        scheduleRepository.deleteAllInBatch();
+        availableDateRepository.deleteAllInBatch();
+        meetingRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("UUID로 약속 정보를 조회한다.")
+    @Test
+    void findByUUID() {
+        // given
+        String uuid = UUID.randomUUID().toString();
+        Guest host = guestRepository.save(new Guest(null, new GuestName("페드로"), ""));
+        String meetingName = "주먹 대결";
+        Meeting boxingWithPedro = meetingRepository.save(
+                new Meeting(
+                        null,
+                        meetingName,
+                        uuid,
+                        Timeslot.TIME_0000,
+                        Timeslot.TIME_0400,
+                        host
+                )
+        );
+        for (int i = 0; i < 7; i++) {
+            availableDateRepository.save(new AvailableDate(null, LocalDate.now().minusDays(i + 1), boxingWithPedro));
+        }
+        AvailableDate availableDate = availableDateRepository.findAll().get(0);
+        scheduleRepository.save(new Schedule(null, boxingWithPedro, host, Timeslot.TIME_0300, availableDate));
+        scheduleRepository.save(new Schedule(null, boxingWithPedro, host, Timeslot.TIME_0100, availableDate));
+
+        // when
+        MeetingResponse result = meetingService.findByUUID(uuid);
+
+        // then
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(result.meetingName()).isEqualTo(meetingName);
+        softAssertions.assertThat(result.availableDates().get(0)).isEqualTo(LocalDate.now().minusDays(1));
+        softAssertions.assertAll();
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #16 

## 작업 내용
- 미팅의 후보 일자
- 미팅 이름
- 시작 시간과 끝 시간
- 현재 미팅에 등록된 시간들

을 조회할 수 있는 API를 작성했습니다.

## 특이 사항
이후 게스트 별 되는 시간을 조회해야 하는 기능이 추가될 것이므로 응답 객체의 `schedules` 리스트의 구조는 변경될 여지가 있습니다.

검증과 예외처리를 추가해야 하고 테스트 코드 역시 추가가 필요해 보입니다 🥲

우선 오늘까지 해커톤으로 진행되니 현재 구현만큼만 머지하고 설계를 하나씩 수정해 봐요

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
