### PR TITLE
chore: 백엔드 CI 액션 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,69 @@
+name: Backend CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['develop']
+
+permissions:
+  checks: write
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+          list-files: 'csv'
+
+  be-test:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant gradlew execute permission
+        run: chmod +x ./gradlew
+
+      - name: Test with Gradle
+        run: ./gradlew clean test
+
+      - name: Publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            backend/build/test-results/test/TEST-*.xml
+
+      - name: Add comments to PR
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: |
+            backend/build/test-results/test/TEST-*.xml


### PR DESCRIPTION
## 관련 이슈

- resolves: #53 

## 작업 내용
백엔드 기능 구현 후 `develop` 브랜치로 PR이 생성되는 경우에 테스트 자동화를 구현했습니다.


## 특이 사항
#53 에서 언급된
> CI action 실패 시 PR이 머지되지 않도록 설정

의 경우 기본 브랜치인 `develop` 브랜치로 워크플로우 파일이 머지되어야 branch protection rule 상에서 설정이 가능할 것 같습니다!


## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
