### PR TITLE
[BE] 약속 생성 API 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -4,11 +4,11 @@ import com.woowacourse.momo.controller.MomoApiResponse;
 import com.woowacourse.momo.service.meeting.MeetingService;
 import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
+import java.net.URI;
 import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,10 +29,15 @@ public class MeetingController {
     }
 
     @PostMapping("/api/v1/meeting")
-    @ResponseStatus(HttpStatus.CREATED)
-    public void create(@RequestBody MeetingCreateRequest request, HttpServletResponse response) {
+    public ResponseEntity<Void> create(@RequestBody MeetingCreateRequest request) {
         String uuid = meetingService.create(request);
-        response.addHeader(HttpHeaders.LOCATION, "/meeting/" + uuid);
+        return ResponseEntity.created(URI.create("/meeting/" + uuid)).build();
+    }
+
+    @GetMapping("/api/v1/meeting/{uuid}/sharing")
+    public MomoApiResponse<MeetingSharingResponse> findMeetingSharing(@PathVariable String uuid) {
+        MeetingSharingResponse response = meetingService.findMeetingSharing(uuid);
+        return new MomoApiResponse<>(response);
     }
 
     @GetMapping("/api/v1/meeting/{uuid}/sharing")

--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -5,7 +5,9 @@ import com.woowacourse.momo.service.meeting.MeetingService;
 import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,8 +30,9 @@ public class MeetingController {
 
     @PostMapping("/api/v1/meeting")
     @ResponseStatus(HttpStatus.CREATED)
-    public void create(@RequestBody MeetingCreateRequest request) {
-        meetingService.create(request);
+    public void create(@RequestBody MeetingCreateRequest request, HttpServletResponse response) {
+        String uuid = meetingService.create(request);
+        response.addHeader(HttpHeaders.LOCATION, "/meeting/" + uuid);
     }
 
     @GetMapping("/api/v1/meeting/{uuid}/sharing")

--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -29,7 +29,8 @@ public class MeetingController {
     @PostMapping("/api/v1/meeting")
     public ResponseEntity<Void> create(@RequestBody MeetingCreateRequest request) {
         String uuid = meetingService.create(request);
-        return ResponseEntity.created(URI.create("/meeting/" + uuid)).build();
+        return ResponseEntity.created(URI.create("/meeting/" + uuid))
+                .build();
     }
 
     @GetMapping("/api/v1/meeting/{uuid}/sharing")

--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -4,16 +4,14 @@ import com.woowacourse.momo.controller.MomoApiResponse;
 import com.woowacourse.momo.service.meeting.MeetingService;
 import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
-import java.net.URI;
 import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
-import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,12 +30,6 @@ public class MeetingController {
     public ResponseEntity<Void> create(@RequestBody MeetingCreateRequest request) {
         String uuid = meetingService.create(request);
         return ResponseEntity.created(URI.create("/meeting/" + uuid)).build();
-    }
-
-    @GetMapping("/api/v1/meeting/{uuid}/sharing")
-    public MomoApiResponse<MeetingSharingResponse> findMeetingSharing(@PathVariable String uuid) {
-        MeetingSharingResponse response = meetingService.findMeetingSharing(uuid);
-        return new MomoApiResponse<>(response);
     }
 
     @GetMapping("/api/v1/meeting/{uuid}/sharing")

--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -2,11 +2,16 @@ package com.woowacourse.momo.controller.meeting;
 
 import com.woowacourse.momo.controller.MomoApiResponse;
 import com.woowacourse.momo.service.meeting.MeetingService;
+import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,6 +24,12 @@ public class MeetingController {
     public MomoApiResponse<MeetingResponse> find(@PathVariable String uuid) {
         MeetingResponse meetingResponse = meetingService.findByUUID(uuid);
         return new MomoApiResponse<>(meetingResponse);
+    }
+
+    @PostMapping("/api/v1/meeting")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(@RequestBody MeetingCreateRequest request) {
+        meetingService.create(request);
     }
 
     @GetMapping("/api/v1/meeting/{uuid}/sharing")

--- a/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDate.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDate.java
@@ -36,7 +36,6 @@ public class AvailableDate extends BaseEntity {
     private Meeting meeting;
 
     public AvailableDate(LocalDate date, Meeting meeting) {
-        this.date = date;
-        this.meeting = meeting;
+        this(null, date, meeting);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDate.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDate.java
@@ -34,4 +34,9 @@ public class AvailableDate extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false)
     private Meeting meeting;
+
+    public AvailableDate(LocalDate date, Meeting meeting) {
+        this.date = date;
+        this.meeting = meeting;
+    }
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDates.java
@@ -1,0 +1,32 @@
+package com.woowacourse.momo.domain.availabledate;
+
+import com.woowacourse.momo.domain.meeting.Meeting;
+import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.code.AvailableDateErrorCode;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class AvailableDates {
+
+    private final List<LocalDate> dates;
+
+    public AvailableDates(List<LocalDate> dates) {
+        validateDuplicatedDates(dates);
+        this.dates = dates;
+    }
+
+    private void validateDuplicatedDates(List<LocalDate> dates) {
+        Set<LocalDate> dateSet = new HashSet<>(dates);
+        if (dateSet.size() != dates.size()) {
+            throw new MomoException(AvailableDateErrorCode.DUPLICATED_DATE);
+        }
+    }
+
+    public List<AvailableDate> assignMeeting(Meeting meeting) {
+        return dates.stream()
+                .map(date -> new AvailableDate(date, meeting))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/availabledate/AvailableDates.java
@@ -7,14 +7,18 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.Getter;
 
+@Getter
 public class AvailableDates {
 
-    private final List<LocalDate> dates;
+    private final List<AvailableDate> dates;
 
-    public AvailableDates(List<LocalDate> dates) {
+    public AvailableDates(List<LocalDate> dates, Meeting meeting) {
         validateDuplicatedDates(dates);
-        this.dates = dates;
+        this.dates = dates.stream()
+                .map(date -> new AvailableDate(date, meeting))
+                .toList();
     }
 
     private void validateDuplicatedDates(List<LocalDate> dates) {
@@ -22,11 +26,5 @@ public class AvailableDates {
         if (dateSet.size() != dates.size()) {
             throw new MomoException(AvailableDateErrorCode.DUPLICATED_DATE);
         }
-    }
-
-    public List<AvailableDate> assignMeeting(Meeting meeting) {
-        return dates.stream()
-                .map(date -> new AvailableDate(date, meeting))
-                .toList();
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/meeting/Meeting.java
@@ -56,10 +56,10 @@ public class Meeting extends BaseEntity {
     }
 
     private void validateTimeRange(Timeslot firstTimeslot, Timeslot lastTimeslot) {
-        if (lastTimeslot == firstTimeslot) {
+        if (firstTimeslot == lastTimeslot) {
             return;
         }
-        if (!lastTimeslot.isAfter(firstTimeslot)) {
+        if (firstTimeslot.isNotBefore(lastTimeslot)) {
             throw new MomoException(MeetingErrorCode.INVALID_TIME_RANGE);
         }
     }

--- a/backend/src/main/java/com/woowacourse/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/meeting/Meeting.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -48,6 +49,10 @@ public class Meeting extends BaseEntity {
         this.uuid = uuid;
         this.firstTimeslot = firstTimeslot;
         this.lastTimeslot = lastTimeslot;
+    }
+
+    public Meeting(String name, String uuid, LocalTime firstTime, LocalTime lastTime) {
+        this(name, uuid, Timeslot.from(firstTime), Timeslot.from(lastTime.minusMinutes(30)));
     }
 
     private void validateTimeRange(Timeslot firstTimeslot, Timeslot lastTimeslot) {

--- a/backend/src/main/java/com/woowacourse/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/meeting/Meeting.java
@@ -2,6 +2,8 @@ package com.woowacourse.momo.domain.meeting;
 
 import com.woowacourse.momo.domain.BaseEntity;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
+import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.code.MeetingErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -41,9 +43,19 @@ public class Meeting extends BaseEntity {
     private Timeslot lastTimeslot;
 
     public Meeting(String name, String uuid, Timeslot firstTimeslot, Timeslot lastTimeslot) {
+        validateTimeRange(firstTimeslot, lastTimeslot);
         this.name = name;
         this.uuid = uuid;
         this.firstTimeslot = firstTimeslot;
         this.lastTimeslot = lastTimeslot;
+    }
+
+    private void validateTimeRange(Timeslot firstTimeslot, Timeslot lastTimeslot) {
+        if (lastTimeslot == firstTimeslot) {
+            return;
+        }
+        if (!lastTimeslot.isAfter(firstTimeslot)) {
+            throw new MomoException(MeetingErrorCode.INVALID_TIME_RANGE);
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
@@ -68,4 +68,8 @@ public enum Timeslot {
                 .findAny()
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 타임슬롯입니다."));
     }
+
+    public boolean isAfter(Timeslot timeslot) {
+        return this.time.isAfter(timeslot.time);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/timeslot/Timeslot.java
@@ -69,7 +69,7 @@ public enum Timeslot {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 타임슬롯입니다."));
     }
 
-    public boolean isAfter(Timeslot timeslot) {
-        return this.time.isAfter(timeslot.time);
+    public boolean isNotBefore(Timeslot timeslot) {
+        return !this.time.isBefore(timeslot.time);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/exception/code/AvailableDateErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/exception/code/AvailableDateErrorCode.java
@@ -2,7 +2,7 @@ package com.woowacourse.momo.exception.code;
 
 import org.springframework.http.HttpStatus;
 
-public enum AvailableDateErrorCode implements ErrorCodeType{
+public enum AvailableDateErrorCode implements ErrorCodeType {
 
     DUPLICATED_DATE(HttpStatus.BAD_REQUEST, "같은 날짜를 중복으로 선택할 수 없습니다.");
 

--- a/backend/src/main/java/com/woowacourse/momo/exception/code/AvailableDateErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/exception/code/AvailableDateErrorCode.java
@@ -1,0 +1,31 @@
+package com.woowacourse.momo.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public enum AvailableDateErrorCode implements ErrorCodeType{
+
+    DUPLICATED_DATE(HttpStatus.BAD_REQUEST, "같은 날짜를 중복으로 선택할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    AvailableDateErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public String errorCode() {
+        return name();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/exception/code/MeetingErrorCode.java
@@ -4,7 +4,8 @@ import org.springframework.http.HttpStatus;
 
 public enum MeetingErrorCode implements ErrorCodeType {
 
-    INVALID_UUID(HttpStatus.BAD_REQUEST, "유효하지 않은 UUID 입니다.");
+    INVALID_UUID(HttpStatus.BAD_REQUEST, "유효하지 않은 UUID 입니다."),
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "끝 시간은 시작 시간 이후가 되어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -66,7 +66,7 @@ public class MeetingService {
     public String create(MeetingCreateRequest request) {
         String uuid = UUID.randomUUID().toString();
         Meeting meeting = new Meeting(
-                request.hostName(),
+                request.meetingName(),
                 uuid,
                 Timeslot.from(request.meetingStartTime()),
                 Timeslot.from(request.meetingEndTime())

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -58,10 +58,11 @@ public class MeetingService {
         return MeetingResponse.from(meeting, dates, list);
     }
 
-    public void create(MeetingCreateRequest request) {
+    public String create(MeetingCreateRequest request) {
+        String uuid = UUID.randomUUID().toString();
         Meeting meeting = new Meeting(
                 request.hostName(),
-                UUID.randomUUID().toString(),
+                uuid,
                 Timeslot.from(request.meetingStartTime()),
                 Timeslot.from(request.meetingEndTime())
         );
@@ -74,6 +75,7 @@ public class MeetingService {
         availableDateRepository.saveAll(availableDates);
 
         attendeeRepository.save(new Attendee(savedMeeting, request.hostName(), request.hostPassword(), Role.HOST));
+        return uuid;
     }
 
     public MeetingSharingResponse findMeetingSharing(String uuid) {

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -5,13 +5,12 @@ import com.woowacourse.momo.domain.attendee.AttendeeRepository;
 import com.woowacourse.momo.domain.attendee.Role;
 import com.woowacourse.momo.domain.availabledate.AvailableDate;
 import com.woowacourse.momo.domain.availabledate.AvailableDateRepository;
+import com.woowacourse.momo.domain.availabledate.AvailableDates;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.meeting.MeetingRepository;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
-import com.woowacourse.momo.exception.MomoException;
-import com.woowacourse.momo.exception.code.AvailableDateErrorCode;
 import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
@@ -20,11 +19,9 @@ import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
 import com.woowacourse.momo.service.schedule.dto.ScheduleTimeResponse;
 import java.time.LocalDate;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -73,11 +70,8 @@ public class MeetingService {
         );
         Meeting savedMeeting = meetingRepository.save(meeting);
 
-        List<LocalDate> dates = request.meetingAvailableDates();
-        validateDuplicatedDates(dates);
-        List<AvailableDate> availableDates = dates.stream()
-                .map(availableDate -> new AvailableDate(availableDate, savedMeeting))
-                .toList();
+        AvailableDates dates = new AvailableDates(request.meetingAvailableDates());
+        List<AvailableDate> availableDates = dates.assignMeeting(savedMeeting);
         availableDateRepository.saveAll(availableDates);
 
         Attendee attendee = new Attendee(savedMeeting, request.hostName(), request.hostPassword(), Role.HOST);

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -10,7 +10,6 @@ import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.meeting.MeetingRepository;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
-import com.woowacourse.momo.domain.timeslot.Timeslot;
 import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
 import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
@@ -65,8 +64,8 @@ public class MeetingService {
         Meeting meeting = new Meeting(
                 request.meetingName(),
                 uuid,
-                Timeslot.from(request.meetingStartTime()),
-                Timeslot.from(request.meetingEndTime())
+                request.meetingStartTime(),
+                request.meetingEndTime()
         );
         Meeting savedMeeting = meetingRepository.save(meeting);
 

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -58,6 +58,7 @@ public class MeetingService {
         return MeetingResponse.from(meeting, dates, list);
     }
 
+    @Transactional
     public String create(MeetingCreateRequest request) {
         String uuid = UUID.randomUUID().toString();
         Meeting meeting = new Meeting(

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -10,6 +10,8 @@ import com.woowacourse.momo.domain.meeting.MeetingRepository;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
+import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.code.AvailableDateErrorCode;
 import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
@@ -18,9 +20,11 @@ import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
 import com.woowacourse.momo.service.schedule.dto.ScheduleTimeResponse;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +74,7 @@ public class MeetingService {
         Meeting savedMeeting = meetingRepository.save(meeting);
 
         List<LocalDate> dates = request.meetingAvailableDates();
+        validateDuplicatedDates(dates);
         List<AvailableDate> availableDates = dates.stream()
                 .map(availableDate -> new AvailableDate(availableDate, savedMeeting))
                 .toList();
@@ -83,5 +88,12 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
         return MeetingSharingResponse.from(meeting);
+    }
+
+    private void validateDuplicatedDates(List<LocalDate> dates) {
+        Set<LocalDate> dateSet = new HashSet<>(dates);
+        if (dateSet.size() != dates.size()) {
+            throw new MomoException(AvailableDateErrorCode.DUPLICATED_DATE);
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -80,7 +80,8 @@ public class MeetingService {
                 .toList();
         availableDateRepository.saveAll(availableDates);
 
-        attendeeRepository.save(new Attendee(savedMeeting, request.hostName(), request.hostPassword(), Role.HOST));
+        Attendee attendee = new Attendee(savedMeeting, request.hostName(), request.hostPassword(), Role.HOST);
+        attendeeRepository.save(attendee);
         return uuid;
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -70,9 +70,8 @@ public class MeetingService {
         );
         Meeting savedMeeting = meetingRepository.save(meeting);
 
-        AvailableDates dates = new AvailableDates(request.meetingAvailableDates());
-        List<AvailableDate> availableDates = dates.assignMeeting(savedMeeting);
-        availableDateRepository.saveAll(availableDates);
+        AvailableDates availableDates = new AvailableDates(request.meetingAvailableDates(), meeting);
+        availableDateRepository.saveAll(availableDates.getDates());
 
         Attendee attendee = new Attendee(savedMeeting, request.hostName(), request.hostPassword(), Role.HOST);
         attendeeRepository.save(attendee);

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -11,9 +11,9 @@ import com.woowacourse.momo.domain.meeting.MeetingRepository;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
-import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
+import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
 import com.woowacourse.momo.service.schedule.dto.ScheduleTimeResponse;
@@ -83,12 +83,5 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
         return MeetingSharingResponse.from(meeting);
-    }
-
-    private void validateDuplicatedDates(List<LocalDate> dates) {
-        Set<LocalDate> dateSet = new HashSet<>(dates);
-        if (dateSet.size() != dates.size()) {
-            throw new MomoException(AvailableDateErrorCode.DUPLICATED_DATE);
-        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingCreateRequest.java
@@ -10,7 +10,7 @@ public record MeetingCreateRequest(
         @NotBlank String hostName,
         @NotBlank String hostPassword,
         @NotBlank String meetingName,
-        @NotBlank List<LocalDate> meetingAvailableDates,
+        @NotNull List<LocalDate> meetingAvailableDates,
         @NotNull LocalTime meetingStartTime,
         @NotNull LocalTime meetingEndTime
 ) {

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingCreateRequest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.momo.service.meeting.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -9,10 +10,9 @@ public record MeetingCreateRequest(
         @NotBlank String hostName,
         @NotBlank String hostPassword,
         @NotBlank String meetingName,
-        int meetingAttendeeLimit,
-        List<LocalDate> meetingAvailableDates,
-        LocalTime meetingStartTime,
-        LocalTime meetingEndTime
+        @NotBlank List<LocalDate> meetingAvailableDates,
+        @NotNull LocalTime meetingStartTime,
+        @NotNull LocalTime meetingEndTime
 ) {
 
 }

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingCreateRequest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.momo.service.meeting.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record MeetingCreateRequest(
+        @NotBlank String hostName,
+        @NotBlank String hostPassword,
+        @NotBlank String meetingName,
+        int meetingAttendeeLimit,
+        List<LocalDate> meetingAvailableDates,
+        LocalTime meetingStartTime,
+        LocalTime meetingEndTime
+) {
+
+}

--- a/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
@@ -1,5 +1,8 @@
 package com.woowacourse.momo.controller.meeting;
 
+import static org.hamcrest.Matchers.containsString;
+
+import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.domain.attendee.AttendeeRepository;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.meeting.MeetingRepository;
@@ -8,6 +11,9 @@ import com.woowacourse.momo.fixture.MeetingFixture;
 import com.woowacourse.momo.support.IsolateDatabase;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +25,7 @@ import java.util.List;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
 @IsolateDatabase
@@ -82,6 +89,7 @@ class MeetingControllerTest {
                 .when().post("/api/v1/meeting")
                 .then().log().all()
                 .assertThat()
-                .statusCode(HttpStatus.CREATED.value());
+                .statusCode(HttpStatus.CREATED.value())
+                .header(HttpHeaders.LOCATION, containsString("/meeting/"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
@@ -2,12 +2,12 @@ package com.woowacourse.momo.controller.meeting;
 
 import static org.hamcrest.Matchers.containsString;
 
-import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.domain.attendee.AttendeeRepository;
 import com.woowacourse.momo.domain.meeting.Meeting;
 import com.woowacourse.momo.domain.meeting.MeetingRepository;
 import com.woowacourse.momo.fixture.AttendeeFixture;
 import com.woowacourse.momo.fixture.MeetingFixture;
+import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.support.IsolateDatabase;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -18,10 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;

--- a/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
@@ -92,4 +92,26 @@ class MeetingControllerTest {
                 .statusCode(HttpStatus.CREATED.value())
                 .header(HttpHeaders.LOCATION, containsString("/meeting/"));
     }
+
+    @DisplayName("약속을 생성할 때 중복되는 날짜로 요청하면 400을 반환한다.")
+    @Test
+    void createByDuplicatedName() {
+        LocalDate date = LocalDate.of(2024, 7, 24);
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "momoHost",
+                "momo",
+                "momoMeeting",
+                8,
+                List.of(date, date),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0));
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/api/v1/meeting")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
@@ -12,6 +12,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -58,5 +62,26 @@ class MeetingControllerTest {
                 .when().get("/api/v1/meeting/{uuid}/sharing", "1234")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("약속을 생성하면 201 상태코드를 반환한다.")
+    @Test
+    void create() {
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "momoHost",
+                "momo",
+                "momoMeeting",
+                8,
+                List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0));
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post("/api/v1/meeting")
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
@@ -78,7 +78,6 @@ class MeetingControllerTest {
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                8,
                 List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));
@@ -101,7 +100,6 @@ class MeetingControllerTest {
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                8,
                 List.of(date, date),
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));

--- a/backend/src/test/java/com/woowacourse/momo/domain/availabledate/AvailableDatesTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/domain/availabledate/AvailableDatesTest.java
@@ -1,0 +1,44 @@
+package com.woowacourse.momo.domain.availabledate;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.momo.domain.meeting.Meeting;
+import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.code.AvailableDateErrorCode;
+import com.woowacourse.momo.fixture.MeetingFixture;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AvailableDatesTest {
+
+    @DisplayName("가능한 시간의 값이 중복이면 예외가 발생한다.")
+    @Test
+    void throwExceptionWhenDuplicatedDate() {
+        // given
+        Meeting meeting = MeetingFixture.GAME.create();
+        LocalDate date = LocalDate.of(2024, 7, 24);
+        List<LocalDate> dates = List.of(date, date);
+
+        // when then
+        assertThatThrownBy(() -> new AvailableDates(dates, meeting))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
+    }
+
+    @DisplayName("가능한 시간이 중복이 아니면 예외가 발생하지 않는다.")
+    @Test
+    void createAvailableDates() {
+        // given
+        Meeting meeting = MeetingFixture.GAME.create();
+        LocalDate date1 = LocalDate.of(2024, 7, 24);
+        LocalDate date2 = LocalDate.of(2024, 8, 25);
+        List<LocalDate> dates = List.of(date1, date2);
+
+        // when then
+        assertThatCode(() -> new AvailableDates(dates, meeting))
+                .doesNotThrowAnyException();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/domain/meeting/MeetingTest.java
@@ -1,0 +1,28 @@
+package com.woowacourse.momo.domain.meeting;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.momo.domain.timeslot.Timeslot;
+import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.code.MeetingErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MeetingTest {
+
+    @DisplayName("약속 시작 시간이 약속 마지막 시간보다 늦은 시간이면 예외가 발생한다.")
+    @Test
+    void throwExceptionWhenInvalidTimeRange() {
+        assertThatThrownBy(() -> new Meeting("momo", "momo", Timeslot.TIME_1500, Timeslot.TIME_0600))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.INVALID_TIME_RANGE.message());
+    }
+
+    @DisplayName("약속 시작 시간이 마지막 시간과 같으면 예외가 발생하지 않는다.")
+    @Test
+    void doesNotThrowExceptionStartAndEndTimeSame() {
+        assertThatCode(() -> new Meeting("momo", "momo", Timeslot.TIME_1500, Timeslot.TIME_1500))
+                .doesNotThrowAnyException();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/domain/meeting/MeetingTest.java
@@ -1,28 +1,67 @@
 package com.woowacourse.momo.domain.meeting;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.momo.domain.timeslot.Timeslot;
 import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
+import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class MeetingTest {
 
-    @DisplayName("약속 시작 시간이 약속 마지막 시간보다 늦은 시간이면 예외가 발생한다.")
+    @DisplayName("약속 시작 시간이 끝 시간과 같으면 예외가 발생한다.")
     @Test
-    void throwExceptionWhenInvalidTimeRange() {
-        assertThatThrownBy(() -> new Meeting("momo", "momo", Timeslot.TIME_1500, Timeslot.TIME_0600))
+    void throwExceptionWhenEqualStartTimeIsEqualEndTime() {
+        // given
+        LocalTime startTime = LocalTime.of(15, 0);
+        LocalTime endTime = LocalTime.of(15, 0);
+
+        // when then
+        assertThatThrownBy(() -> new Meeting("momo", "momo", startTime, endTime))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(MeetingErrorCode.INVALID_TIME_RANGE.message());
     }
 
-    @DisplayName("약속 시작 시간이 마지막 시간과 같으면 예외가 발생하지 않는다.")
+    @DisplayName("약속 시작 시간이 끝 시간보다 늦으면 예외가 발생한다.")
+    @Test
+    void throwExceptionWhenStartTimeIsAfterEndTime() {
+        // given
+        LocalTime startTime = LocalTime.of(15, 0);
+        LocalTime endTime = LocalTime.of(10, 0);
+
+        // when then
+        assertThatThrownBy(() -> new Meeting("momo", "momo", startTime, endTime))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.INVALID_TIME_RANGE.message());
+    }
+
+    @DisplayName("약속 시작 시간이 끝 시간보다 빠르면 예외가 발생하지 않는다.")
     @Test
     void doesNotThrowExceptionStartAndEndTimeSame() {
-        assertThatCode(() -> new Meeting("momo", "momo", Timeslot.TIME_1500, Timeslot.TIME_1500))
+        // given
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(15, 0);
+
+        // when then
+        assertThatCode(() -> new Meeting("momo", "momo", startTime, endTime))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("자정 시간을 23시 30분 타임슬롯으로 변경한다")
+    @Test
+    void canConvertMidnight() {
+        // given
+        LocalTime startTime = LocalTime.of(10, 0);
+        LocalTime endTime = LocalTime.of(0, 0);
+
+        // when
+        Meeting meeting = new Meeting("momo", "momo", startTime, endTime);
+
+        // when then
+        assertThat(meeting.getLastTimeslot()).isEqualTo(Timeslot.TIME_2330);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -1,6 +1,9 @@
 package com.woowacourse.momo.service.meeting;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.woowacourse.momo.domain.attendee.Attendee;
+import com.woowacourse.momo.domain.attendee.AttendeeName;
 import com.woowacourse.momo.domain.attendee.AttendeeRepository;
 import com.woowacourse.momo.domain.attendee.Role;
 import com.woowacourse.momo.domain.availabledate.AvailableDate;
@@ -14,13 +17,16 @@ import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
 import com.woowacourse.momo.fixture.AttendeeFixture;
 import com.woowacourse.momo.fixture.MeetingFixture;
+import com.woowacourse.momo.service.meeting.dto.MeetingCreateRequest;
 import com.woowacourse.momo.service.meeting.dto.MeetingResponse;
 import com.woowacourse.momo.service.meeting.dto.MeetingSharingResponse;
 import com.woowacourse.momo.support.IsolateDatabase;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +91,58 @@ class MeetingServiceTest {
         softAssertions.assertThat(result.meetingName()).isEqualTo(meetingName);
         softAssertions.assertThat(result.availableDates().get(0)).isEqualTo(LocalDate.now().minusDays(1));
         softAssertions.assertAll();
+    }
+
+    @DisplayName("약속 정보와 참가자 정보를 통해 약속을 등록한다.")
+    @Test
+    void create() {
+        //given
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "momoHost",
+                "momo",
+                "momoMeeting",
+                8,
+                List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0));
+
+        //when
+        meetingService.create(request);
+
+        //then
+        List<Meeting> meetings = meetingRepository.findAll();
+        List<Attendee> attendees = attendeeRepository.findAll();
+        List<AvailableDate> availableDates = availableDateRepository.findAll();
+
+        assertAll(
+                () -> Assertions.assertThat(meetings).hasSize(1),
+                () -> Assertions.assertThat(attendees).hasSize(1),
+                () -> Assertions.assertThat(availableDates).hasSize(2)
+        );
+    }
+
+    @DisplayName("약속을 생성한 참가자의 역할은 호스트이다.")
+    @Test
+    void createdMeetingByHost() {
+        //given
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "momoHost",
+                "momo",
+                "momoMeeting",
+                8,
+                List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0));
+
+        //when
+        meetingService.create(request);
+
+        //then
+        List<Meeting> meetings = meetingRepository.findAll();
+        Attendee attendee = attendeeRepository.findByMeetingAndName(meetings.get(0), new AttendeeName("momoHost"))
+                .orElseThrow();
+
+        Assertions.assertThat(attendee).extracting("role").isEqualTo(Role.HOST);
     }
 
     @DisplayName("생성 완료된 약속의 정보를 조회한다.")

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.momo.service.meeting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.momo.domain.attendee.Attendee;
@@ -16,7 +15,6 @@ import com.woowacourse.momo.domain.meeting.MeetingRepository;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
-import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
 import com.woowacourse.momo.fixture.AttendeeFixture;

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -16,6 +16,7 @@ import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
 import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.code.AvailableDateErrorCode;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
 import com.woowacourse.momo.fixture.AttendeeFixture;
 import com.woowacourse.momo.fixture.MeetingFixture;
@@ -158,7 +159,9 @@ class MeetingServiceTest {
                 LocalTime.of(22, 0));
 
         //when //then
-        assertThatThrownBy(() -> meetingService.create(request)).isInstanceOf(MomoException.class);
+        assertThatThrownBy(() -> meetingService.create(request))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
     }
 
     @DisplayName("생성 완료된 약속의 정보를 조회한다.")

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -1,5 +1,8 @@
 package com.woowacourse.momo.service.meeting;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.momo.domain.attendee.Attendee;
@@ -14,6 +17,7 @@ import com.woowacourse.momo.domain.schedule.Schedule;
 import com.woowacourse.momo.domain.schedule.ScheduleRepository;
 import com.woowacourse.momo.domain.timeslot.Timeslot;
 import com.woowacourse.momo.exception.MomoException;
+import com.woowacourse.momo.exception.MomoException;
 import com.woowacourse.momo.exception.code.MeetingErrorCode;
 import com.woowacourse.momo.fixture.AttendeeFixture;
 import com.woowacourse.momo.fixture.MeetingFixture;
@@ -25,7 +29,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -115,9 +118,9 @@ class MeetingServiceTest {
         List<AvailableDate> availableDates = availableDateRepository.findAll();
 
         assertAll(
-                () -> Assertions.assertThat(meetings).hasSize(1),
-                () -> Assertions.assertThat(attendees).hasSize(1),
-                () -> Assertions.assertThat(availableDates).hasSize(2)
+                () -> assertThat(meetings).hasSize(1),
+                () -> assertThat(attendees).hasSize(1),
+                () -> assertThat(availableDates).hasSize(2)
         );
     }
 
@@ -143,6 +146,26 @@ class MeetingServiceTest {
                 .orElseThrow();
 
         Assertions.assertThat(attendee).extracting("role").isEqualTo(Role.HOST);
+    }
+
+    @DisplayName("약속을 생성할 때 같은 약속일을 2번 이상 보내면 예외가 발생합니다.")
+    @Test
+    void throwExceptionWhenDuplicatedDates() {
+        //given
+        LocalDate date = LocalDate.of(2024, 7, 24);
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "momoHost",
+                "momo",
+                "momoMeeting",
+                8,
+                List.of(date, date),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0));
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> meetingService.create(request)).isInstanceOf(MomoException.class);
     }
 
     @DisplayName("생성 완료된 약속의 정보를 조회한다.")

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -1,8 +1,5 @@
 package com.woowacourse.momo.service.meeting;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.woowacourse.momo.domain.attendee.Attendee;
 import com.woowacourse.momo.domain.attendee.AttendeeRepository;
 import com.woowacourse.momo.domain.attendee.Role;
@@ -23,6 +20,7 @@ import com.woowacourse.momo.support.IsolateDatabase;
 import java.time.LocalDate;
 import java.util.UUID;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -143,7 +143,7 @@ class MeetingServiceTest {
         Attendee attendee = attendeeRepository.findByMeetingAndName(meetings.get(0), new AttendeeName("momoHost"))
                 .orElseThrow();
 
-        Assertions.assertThat(attendee).extracting("role").isEqualTo(Role.HOST);
+        assertThat(attendee.getRole()).isEqualTo(Role.HOST);
     }
 
     @DisplayName("약속을 생성할 때 같은 약속일을 2번 이상 보내면 예외가 발생합니다.")
@@ -159,9 +159,7 @@ class MeetingServiceTest {
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));
 
-        //when
-
-        //then
+        //when //then
         assertThatThrownBy(() -> meetingService.create(request)).isInstanceOf(MomoException.class);
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -104,7 +104,6 @@ class MeetingServiceTest {
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                8,
                 List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));
@@ -132,7 +131,6 @@ class MeetingServiceTest {
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                8,
                 List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));
@@ -157,7 +155,6 @@ class MeetingServiceTest {
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                8,
                 List.of(date, date),
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));


### PR DESCRIPTION
## 관련 이슈

- resolves: #51 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

약속을 생성하는 기능을 구현합니다.

로직은 아래와 같은 순서로 동작합니다.
* 주최자를 참여자로 등록(회원가입)합니다.
* 약속 허용날짜(avilableDates)를 저장합니다.
* 약속(Meeting)을 저장합니다.

요청
```http
POST /api/v1/meeting HTTP/1.1

{
    "hostName": "momo_host",
    "hostPassword": "momo_password",
    "meetingName": "momo_meeting",
    "meetingAvailableDates": [
        "2024-07-20",
        "2024-07-21",
        "2024-07-22"
    ],
    "meetingStartTime": "8:00",
    "meetingEndTime": "22:00"
}
```

응답
```http
HTTP/1.1 201 Created
Location: /meeting/{uuid}
```

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

1. PRG(Post-Redirect-Get)의 필요성
구현한 약속 생성 API는 아래와 같은 로직입니다.
>     (1) 약속 생성 등록 페이지에서 등록 버튼을 누르면 POST 요청
>     (2) 정보 페이지로 이동하면서 응답받은 값을 정보 페이지에 뿌려줌
그러나 이렇게 구현하면 사용자가 새로고침을 할 경우 POST 재요청되고, 또 다른 Meeting이 생성될 것으로 예상됩니다.
만약 예상한 대로 동작한다면, 리다이렉트하여 새로고침 시 GET 요청이 가도록 수정할 예정입니다.

2. UUID 라이브러리
UUID 버전은 사전에 논의한 내용과 아래 자료를 참고하여 v4로 선택했습니다.
[baeldung-java-uuid](https://www.baeldung.com/java-uuid)
[which-uuid-version-to-use](https://stackoverflow.com/questions/20342058/which-uuid-version-to-use)


## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

1. 약속 허용 날짜가 중복되었는지 검증하는 로직 위치
날짜(ex. `2023-07-01`)가 중복으로 2번 들어갔는지 확인하는 검증하는 로직(`validateDuplicatedDates`)을 `MeetingService`에 두었는데 적절한 위치인지 고민됩니다.
`request`나 `domain`에서 검증해야 할 것 같은데, 보통 어떻게 하시나요?

2. 생성된 `Meeting`의 uuid를 클라이언트에게 제공하는 방식
구현한 API는 생성된 `Meeting`의 `uuid`를 `Location`헤더를 통해 제공됩니다. 이것이 적절한 방식인지 의견을 나누고 싶어요!
이미 `Location` 헤더에 이미 존재하는데, 응답 바디를 통해 `uuid`를 따로 제공하는 것이 중복이라 생각하여 응답 바디를 따로 두지 않았습니다.
그러나 `Location`의 역할은 생성된 리소스의 위치를 알려주는 것이지 `uuid`라는 식별자를 알려주는 것이 아닌 것 같아서 고민이 됩니다 🤔

