### PR TITLE
[BE] 백엔드 CD 자동화 환경 구축

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: ['develop']
+  pull_request:  # PR 액션 테스트용 임시 추가
+    branches: ['develop']
 
 jobs:
   detect-changes:

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: ['develop']
-  pull_request:  # PR 액션 테스트용 임시 추가
-    branches: ['develop']
 
 jobs:
   detect-changes:
@@ -50,8 +48,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-#        with:
-#          ref: develop
+        with:
+          ref: develop
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: actions/checkout@v4  # Push 이벤트이기 때문에 checkout 해야 함
         with:
+          ref: develop
           submodules: recursive
           token: ${{ secrets.PAT_TOKEN }}
       - uses: dorny/paths-filter@v3
@@ -49,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+#        with:
+#          ref: develop
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -1,0 +1,113 @@
+name: Backend CD
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['develop']
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      manual: ${{ steps.manualcheck.outputs.manual }}
+    steps:
+      - id: manualcheck
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "manual=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4  # Push 이벤트이기 때문에 checkout 해야 함
+        with:
+          submodules: recursive
+          token: ${{ secrets.PAT_TOKEN }}
+      - uses: dorny/paths-filter@v3
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        id: filter
+        with:
+          base: 'develop'  # 해당 브랜치의 last commit과 변경점 비교
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+  be-build:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.manual == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./backend
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant gradlew execute permission
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle (clean)
+        run: ./gradlew clean bootJar
+
+      # Docker 이미지 빌드
+      - name: Docker image build
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/momo-api .
+
+      # DockerHub 로그인
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Docker Hub 이미지 푸시
+      - name: Docker Hub push
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
+
+  be-depoly:
+    needs: be-build
+    runs-on: self-hosted
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./
+
+    steps:
+      - name: checkout security submodule
+        uses: actions/checkout@v4
+        with:
+          repository: woowacourse-teams/2024-momo-config
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: copy security config
+        run: mkdir -p $HOME/security; \cp -f *.yml ~/security
+
+      # 1. 최신 도커 이미지 pull
+      - name: docker pull
+        run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
+
+      # 2. 기존 컨테이너 중지
+      - name: docker stop container
+        run: docker stop $(docker ps -q) 2>/dev/null || true
+
+      # 3. 도커 컨테이너 실행
+      - name: docker run new container
+        run: docker run --name momo-api --rm -d -p 80:8080 --volume=$HOME/security:/security:ro ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
+
+      # 4. 미사용 이미지를 정리
+      - name: delete old docker image
+        run: docker system prune -f

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "backend/src/main/resources/security"]
+	path = backend/src/main/resources/security
+	url = https://github.com/woowacourse-teams/2024-momo-config

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,4 @@
+FROM --platform=linux/arm64 openjdk:17-ea-11
+
+COPY build/libs/*.jar momo-api.jar
+ENTRYPOINT ["java","-jar","/momo-api.jar", "--spring.config.location=file:/security/"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -44,3 +44,7 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+bootJar {
+    exclude('*.yml')
+}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,3 +48,10 @@ test {
 bootJar {
     exclude('*.yml')
 }
+
+processResources.dependsOn('copyYML')
+tasks.register('copyYML', Copy) {
+    from 'src/main/resources/security' // 서브 모듈 경로
+    include "*.yml"
+    into 'src/main/resources'
+}


### PR DESCRIPTION
## 관련 이슈

- resolves #59
- resolves #65 

## 작업 내용

백엔드 기능 구현 후 `develop` 브랜치에 머지되었을 때 배포 자동화 환경을 구축했습니다.
#59 에서 언급했던 것 처럼 현재는 개발서버에 대한 CD에 가까운데요, 이후 릴리즈 브랜치가 생기면 프로덕션 배포 자동화도 별개로 추가해야 할 듯 합니다!

`develop` 브랜치의 `/backend` 경로 하위에 변경사항이 발생할 경우 다음과 같은 순서로 배포를 진행합니다.
1. `bootJar` 빌드
2. `jar`을 포함한 Docker 이미지 빌드 후 Docker Hub 업로드
3. EC2 인스턴스에서 Docker 이미지 pull -> 컨테이너 실행

* 3번 작업은 EC2 인바운드 제한 정책을 준수하기 위해 self-hosted runner에서 동작합니다.

## 특이 사항

`application.yml` 과 같은 중요 프로퍼티를 외부에 공개하지 않기 위해 `git submodule` 을 사용합니다.
비공개 레포지토리는 [`/2024-momo-config`](https://github.com/woowacourse-teams/2024-momo-config)이며, **변경사항 발생 시 `pull` 해야 하므로 프론트 크루분들도 함께 콜라보레이터로 초대해 두었습니다.**

레포지토리 내 서브모듈의 경로는 다음과 같습니다.
```text
/backend/src/main/resources/security
```

본 PR 병합 이후 `develop`에서 분기하는 브랜치의 `application.yml`은 서브모듈 내의 `yml` 파일로 관리해야 합니다.

서브모듈 내의 프로퍼티들을 `classpath`로 복사하기 위해 다음과 같은 `Gradle task`를 활용합니다.
**해당 테스크는 `.../resources/` 경로 내의 동일한 파일명을 가진 `*.yml`을 덮어 씀에 유의하세요.**

```groovy
tasks.register('copyYML', Copy) {
    from 'src/main/resources/security' // Submodule path
    include "*.yml"
    into 'src/main/resources'
}
```

---

로컬 레포지토리에 서브모듈 설정이 되어 있지 않다면 서브모듈을 직접 추가해야 합니다.
```bash
$ git submodule init
$ git submodule update --remote --merge  // 이후 서브모듈이 업데이트됐을 때, 명령으로 변경사항을 가져옵니다.
```

**서브모듈은 원본 레포지토리와 독립된 하나의 레포지토리입니다.**
원본 레포지토리는 서브모듈의 참조 해시 정보만을 가지고 있으므로, 서브모듈에 변경사항이 생긴 경우 항상 서브모듈부터 커밋 & 푸시 후 원본 레포지토리에 푸시해야 합니다.
(순서가 어긋날 경우 `git diff` 체크에서 서브모듈의 파일이 변경사항으로 감지되어 레포지토리가 꼬일 수 있어요🥲)
```bash
$ (momo) cd <path-to-submodule>
$ (momo-config) git commit -m "submodule 업데이트"
$ (momo-config) git push origin main
$ (momo) cd <path-to-parent-repo>
$ (momo) git commit -m "submodule 업데이트 반영"
$ (momo) git push origin <branch-name>
```

[submodule 레퍼런스](https://gist.github.com/gitaarik/8735255)

## 리뷰 요구사항 (선택)

Github Action 의 `on: push` 트리거 특성 상, 레포지토리의 기본 브랜치(현재는 `develop`)에 워크플로우 파일이 머지되어야 Actions 탭에서 활성화됩니다.

PR 작성 시점에는 워크플로우를 직접 실행할 수 없어 테스트를 위해 부득이하게 트리거를 임시로 변경(5dbc9df) 한 후, 다시 복구 (4db6361) 해 뒀어요.
테스트 할 수 있는 만큼은 최대한 테스트 후 리뷰 요청 드리지만, 실제 문제가 없는지는 PR 머지 이후에 확인할 수 있을 것 같습니다😅

---
현재는 간단히 `application.yml` 하나로 설정을 관리하고 있지만, 이후 프로필이 다양해지거나 설정할 것들이 많아지면 `application.yml`을 `.gitignore`에서 해제하고, 중요 비밀들은 [`security 서브모듈`](https://github.com/woowacourse-teams/2024-momo-config) 내의 yml 파일을 임포트하여 사용하는 방식을 취하면 좋을 것 같네요~
