### PR TITLE
[BE] 기존 약속 정보 조회 API 응답에 참가자들의 정보 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/domain/attendee/AttendeeRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/attendee/AttendeeRepository.java
@@ -1,10 +1,13 @@
 package com.woowacourse.momo.domain.attendee;
 
 import com.woowacourse.momo.domain.meeting.Meeting;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttendeeRepository extends JpaRepository<Attendee, Long> {
 
     Optional<Attendee> findByMeetingAndName(Meeting meeting, AttendeeName name);
+
+    List<Attendee> findAllByMeeting(Meeting meeting);
 }

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -56,8 +56,9 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
         AvailableDates availableDates = new AvailableDates(availableDateRepository.findAllByMeeting(meeting));
+        List<Attendee> attendees = attendeeRepository.findAllByMeeting(meeting);
 
-        return MeetingResponse.from(meeting, availableDates);
+        return MeetingResponse.of(meeting, availableDates, attendees);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/dto/MeetingResponse.java
@@ -2,6 +2,7 @@ package com.woowacourse.momo.service.meeting.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.woowacourse.momo.domain.attendee.Attendee;
 import com.woowacourse.momo.domain.availabledate.AvailableDate;
 import com.woowacourse.momo.domain.availabledate.AvailableDates;
 import com.woowacourse.momo.domain.meeting.Meeting;
@@ -14,19 +15,25 @@ public record MeetingResponse(
         String meetingName,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") LocalTime firstTime,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") LocalTime lastTime,
-        List<LocalDate> availableDates
+        List<LocalDate> availableDates,
+        List<String> attendeeNames
 ) {
 
-    public static MeetingResponse from(Meeting meeting, AvailableDates availableDates) {
+    public static MeetingResponse of(Meeting meeting, AvailableDates availableDates, List<Attendee> attendees) {
         List<LocalDate> dates = availableDates.getAvailableDates().stream()
                 .map(AvailableDate::getDate)
                 .collect(Collectors.toList());
+
+        List<String> attendeeNames = attendees.stream()
+                .map(Attendee::name)
+                .toList();
 
         return new MeetingResponse(
                 meeting.getName(),
                 meeting.startTimeslotTime(),
                 meeting.endTimeslotTime(),
-                dates
+                dates,
+                attendeeNames
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/meeting/MeetingServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import com.woowacourse.momo.domain.attendee.Attendee;
 import com.woowacourse.momo.domain.attendee.AttendeeRepository;
 import com.woowacourse.momo.domain.availabledate.AvailableDate;
 import com.woowacourse.momo.domain.availabledate.AvailableDateRepository;
@@ -47,6 +48,7 @@ class MeetingServiceTest {
     @Test
     void findByUUID() {
         Meeting meeting = meetingRepository.save(MeetingFixture.MOVIE.create());
+        Attendee attendee = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
         List<AvailableDate> availableDates = List.of(
                 availableDateRepository.save(new AvailableDate(LocalDate.now(), meeting)),
                 availableDateRepository.save(new AvailableDate(LocalDate.now().plusDays(1), meeting))
@@ -59,6 +61,7 @@ class MeetingServiceTest {
             softAssertions.assertThat(response.lastTime()).isEqualTo(meeting.endTimeslotTime());
             softAssertions.assertThat(response.meetingName()).isEqualTo(meeting.getName());
             softAssertions.assertThat(response.availableDates().size()).isEqualTo(availableDates.size());
+            softAssertions.assertThat(response.attendeeNames()).isEqualTo(List.of(attendee.name()));
         });
     }
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #80 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- 기존에 존재하는 약속 정보 조회 API 응답에 참가자들의 이름 리스트를 추가하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
