### PR TITLE
[BE] 참가자 스케줄 조회 반환 값 내 시간 포멧팅 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/service/schedule/dto/ScheduleDateTimesResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/schedule/dto/ScheduleDateTimesResponse.java
@@ -3,6 +3,8 @@ package com.woowacourse.momo.service.schedule.dto;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.woowacourse.momo.domain.schedule.Schedule;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -10,7 +12,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public record ScheduleDateTimesResponse(LocalDate date, List<LocalTime> times) {
+public record ScheduleDateTimesResponse(
+        LocalDate date,
+        @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") List<LocalTime> times
+) {
 
     public static List<ScheduleDateTimesResponse> from(List<Schedule> schedules) {
         Map<LocalDate, List<LocalTime>> results = schedules.stream()


### PR DESCRIPTION
## 관련 이슈

- resolves: #84 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- `ScheduleDateTimesResponse`의 시간 필드 앞 `@JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")` 어노테이션을 추가하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
