### PR TITLE
[BE] 약속 생성 API에서 바디를 통해 uuid를 제공

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -28,10 +28,12 @@ public class MeetingController {
     }
 
     @PostMapping("/api/v1/meeting")
-    public ResponseEntity<Void> create(@RequestBody @Valid MeetingCreateRequest request) {
-        String uuid = meetingService.create(request);
-        return ResponseEntity.created(URI.create("/meeting/" + uuid))
-                .build();
+    public ResponseEntity<MomoApiResponse<MeetingSharingResponse>> create(
+            @RequestBody @Valid MeetingCreateRequest request
+    ) {
+        MeetingSharingResponse response = meetingService.create(request);
+        return ResponseEntity.created(URI.create("/meeting/" + response.uuid()))
+                .body(new MomoApiResponse<>(response));
     }
 
     @GetMapping("/api/v1/meeting/{uuid}/sharing")

--- a/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/meeting/MeetingService.java
@@ -29,11 +29,11 @@ public class MeetingService {
     private final AttendeeRepository attendeeRepository;
 
     @Transactional
-    public String create(MeetingCreateRequest request) {
+    public MeetingSharingResponse create(MeetingCreateRequest request) {
         Meeting meeting = saveMeeting(request.meetingName(), request.meetingStartTime(), request.meetingEndTime());
         saveAvailableDates(request.meetingAvailableDates(), meeting);
         saveHostAttendee(meeting, request.hostName(), request.hostPassword());
-        return meeting.getUuid();
+        return MeetingSharingResponse.from(meeting);
     }
 
     private Meeting saveMeeting(String meetingName, LocalTime startTime, LocalTime endTime) {


### PR DESCRIPTION
## 관련 이슈

- resolves: #83 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
약속을 생성할 때, 약속의 uuid를 응답 바디에 넣어 보냅니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
