### PR TITLE
[BE] Swagger UI 임시 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
     implementation 'com.auth0:java-jwt:4.4.0'
 
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/woowacourse/momo/config/swagger/SwaggerConfig.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/swagger/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.woowacourse.momo.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${apiVersion}")
+    private static String apiVersion;
+
+    @Bean
+    public OpenAPI openAPI() {
+        Components authComponent = new Components().addSecuritySchemes("Bearer Token", apiAuth());
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("Bearer Token");
+
+        return new OpenAPI()
+                .info(apiInfo())
+                .components(authComponent)
+                .addSecurityItem(securityRequirement);
+    }
+
+    private SecurityScheme apiAuth() {
+        return new SecurityScheme().type(Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("momo API")
+                .description("momo API 입니다.")
+                .version(apiVersion);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #89 

## 작업 내용

Swagger UI를 적용했습니다.
API인증에 사용될 Bearer 토큰을 설정하는 버튼을 생성하기 위한 설정을 제외한 추가적인 설정은 아직 하지 않았습니다.

`GET /api/docs` 로 접속하면 Swagger UI를 확인할 수 있습니다.

## 특이 사항

`application.yml`에 설정이 추가되면서 submodule에 변경사항이 생겼습니다.
서브모듈 업데이트 하세요~

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
