### PR TITLE
[ALL] RESTful API 디자인 원칙에 기반하여 기존 API path를 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/attendee/AttendeeController.java
@@ -17,7 +17,7 @@ public class AttendeeController {
 
     private final AttendeeService attendeeService;
 
-    @PostMapping("/api/v1/login/{uuid}")
+    @PostMapping("/api/v1/meetings/{uuid}/login")
     public MomoApiResponse<TokenResponse> login(
             @PathVariable String uuid, @RequestBody @Valid AttendeeLoginRequest request
     ) {

--- a/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/meeting/MeetingController.java
@@ -21,13 +21,7 @@ public class MeetingController {
 
     private final MeetingService meetingService;
 
-    @GetMapping("/api/v1/meeting/{uuid}")
-    public MomoApiResponse<MeetingResponse> find(@PathVariable String uuid) {
-        MeetingResponse meetingResponse = meetingService.findByUUID(uuid);
-        return new MomoApiResponse<>(meetingResponse);
-    }
-
-    @PostMapping("/api/v1/meeting")
+    @PostMapping("/api/v1/meetings")
     public ResponseEntity<MomoApiResponse<MeetingSharingResponse>> create(
             @RequestBody @Valid MeetingCreateRequest request
     ) {
@@ -36,7 +30,13 @@ public class MeetingController {
                 .body(new MomoApiResponse<>(response));
     }
 
-    @GetMapping("/api/v1/meeting/{uuid}/sharing")
+    @GetMapping("/api/v1/meetings/{uuid}")
+    public MomoApiResponse<MeetingResponse> find(@PathVariable String uuid) {
+        MeetingResponse meetingResponse = meetingService.findByUUID(uuid);
+        return new MomoApiResponse<>(meetingResponse);
+    }
+
+    @GetMapping("/api/v1/meetings/{uuid}/sharing")
     public MomoApiResponse<MeetingSharingResponse> findMeetingSharing(@PathVariable String uuid) {
         MeetingSharingResponse response = meetingService.findMeetingSharing(uuid);
         return new MomoApiResponse<>(response);

--- a/backend/src/main/java/com/woowacourse/momo/controller/schedule/ScheduleController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/schedule/ScheduleController.java
@@ -20,20 +20,20 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @PostMapping("/api/v1/schedule/{uuid}")
+    @PostMapping("/api/v1/meetings/{uuid}/schedules")
     public void create(
             @PathVariable String uuid, @AuthAttendee long id, @RequestBody @Valid ScheduleCreateRequest request
     ) {
         scheduleService.create(uuid, id, request);
     }
 
-    @GetMapping("/api/v1/meeting/{uuid}/schedules")
+    @GetMapping("/api/v1/meetings/{uuid}/schedules")
     public MomoApiResponse<SchedulesResponse> findAllSchedules(@PathVariable String uuid) {
         SchedulesResponse response = scheduleService.findAllSchedules(uuid);
         return new MomoApiResponse<>(response);
     }
 
-    @GetMapping(path = "/api/v1/meeting/{uuid}/schedules", params = "attendeeName")
+    @GetMapping(path = "/api/v1/meetings/{uuid}/schedules", params = "attendeeName")
     public MomoApiResponse<ScheduleOneAttendeeResponse> findSchedulesOfAttendee(
             @PathVariable String uuid, String attendeeName
     ) {
@@ -41,7 +41,7 @@ public class ScheduleController {
         return new MomoApiResponse<>(response);
     }
 
-    @GetMapping("/api/v1/meeting/{uuid}/my-schedule")
+    @GetMapping("/api/v1/meetings/{uuid}/attendees/me/schedules")
     public MomoApiResponse<ScheduleOneAttendeeResponse> findMySchedule(
             @PathVariable String uuid, @AuthAttendee long id
     ) {

--- a/backend/src/test/java/com/woowacourse/momo/controller/attendee/AttendeeControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/attendee/AttendeeControllerTest.java
@@ -50,7 +50,7 @@ class AttendeeControllerTest {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
-                .when().post("/api/v1/login/{uuid}", meeting.getUuid())
+                .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }

--- a/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/meeting/MeetingControllerTest.java
@@ -62,7 +62,7 @@ class MeetingControllerTest {
 
         Response response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/meeting/{uuid}", meeting.getUuid());
+                .when().get("/api/v1/meetings/{uuid}", meeting.getUuid());
 
         String meetingName = response.jsonPath().getString("data.meetingName");
         String firstTime = response.jsonPath().getString("data.firstTime");
@@ -87,7 +87,7 @@ class MeetingControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/meeting/{uuid}/sharing", meeting.getUuid())
+                .when().get("/api/v1/meetings/{uuid}/sharing", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -97,7 +97,7 @@ class MeetingControllerTest {
     void findMeetingSharingFailedWithInvalidUUID() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/meeting/{uuid}/sharing", "1234")
+                .when().get("/api/v1/meetings/{uuid}/sharing", "1234")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
@@ -116,7 +116,7 @@ class MeetingControllerTest {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
-                .when().post("/api/v1/meeting")
+                .when().post("/api/v1/meetings")
                 .then().log().all()
                 .assertThat()
                 .statusCode(HttpStatus.CREATED.value())
@@ -138,7 +138,7 @@ class MeetingControllerTest {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(request)
-                .when().post("/api/v1/meeting")
+                .when().post("/api/v1/meetings")
                 .then().log().all()
                 .assertThat()
                 .statusCode(HttpStatus.BAD_REQUEST.value());

--- a/backend/src/test/java/com/woowacourse/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/controller/schedule/ScheduleControllerTest.java
@@ -71,7 +71,7 @@ class ScheduleControllerTest {
         String token = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(loginRequest)
-                .when().post("/api/v1/login/{uuid}", meeting.getUuid())
+                .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().jsonPath().getString("data.token");
@@ -89,7 +89,7 @@ class ScheduleControllerTest {
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
                 .body(scheduleCreateRequest)
-                .when().post("/api/v1/schedule/{uuid}")
+                .when().post("/api/v1/meetings/{uuid}/schedules")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -102,7 +102,7 @@ class ScheduleControllerTest {
         RestAssured.given().log().all()
                 .pathParam("uuid", meeting.getUuid())
                 .queryParam("attendeeName", attendee.name())
-                .when().get("/api/v1/meeting/{uuid}/schedules")
+                .when().get("/api/v1/meetings/{uuid}/schedules")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -112,7 +112,7 @@ class ScheduleControllerTest {
     void findAllSchedules() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/meeting/{uuid}/schedules", meeting.getUuid())
+                .when().get("/api/v1/meetings/{uuid}/schedules", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -127,7 +127,7 @@ class ScheduleControllerTest {
         String token = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(loginRequest)
-                .when().post("/api/v1/login/{uuid}", meeting.getUuid())
+                .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().jsonPath().getString("data.token");
@@ -136,7 +136,7 @@ class ScheduleControllerTest {
                 .header("Authorization", "Bearer " + token)
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/meeting/{uuid}/my-schedule")
+                .when().get("/api/v1/meetings/{uuid}/attendees/me/schedules")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }


### PR DESCRIPTION
## 관련 이슈

- resolves: #104 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

RESTful API 디자인 원칙에 기반하여 현재 구현되어 있는 API Path를 개선하였습니다.

### Path 변경 사항
| 기능                           | HTTP 메서드 | URI 경로                                   |
| ------------------------------ | ----------- | ------------------------------------------ |
| 참가자 로그인                  | POST        | /api/v1/meetings/{uuid}/login            |
| 약속 정보 생성                 | POST        | /api/v1/meetings                         |
| 약속 정보 조회                 | GET         | /api/v1/meetings/{uuid}                  |
| 약속 공유 조회                 | GET         | /api/v1/meetings/{uuid}/sharing          |
| 일정 생성                      | POST        | /api/v1/meetings/{uuid}/schedules        |
| 약속의 모든 일정 조회          | GET         | /api/v1/meetings/{uuid}/schedules        |
| 약속의 특정 회원 일정 조회     | GET         | /api/v1/meetings/{uuid}/schedules?attendeeName=        |
| 약속의 내 일정 조회            | GET         | /api/v1/meetings/{uuid}/attendees/me/schedules |

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- 자원 식별 혼동을 줄이기 위해 모든 자원에 대해 복수형 명사를 사용하였습니다.
- uuid를 사용하는 path에 일괄적으로 meetings를 명시하여 계층 구분을 명확히 하였습니다.
- 약속의 내 일정 조회 기능의 경우 현재 인증된 사용자 정보로 일정에 접근하는 의미를 명확히 하도록 수정하였습니다.
    - 자원의 계층을 분리하여 URI 일관성을 유지하였습니다.
    - me 키워드를 통해 현재 일정 자원에 접근하는 참가자가 인증된 참가자라는 의미를 포함합니다. 

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
