### PR TITLE
[BE] 약속 잠금 API 추가

### DIFF
--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -11,6 +11,7 @@ import kr.momo.service.meeting.dto.MeetingSharingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,7 +44,7 @@ public class MeetingController {
         return new MomoApiResponse<>(response);
     }
 
-    @PostMapping("/api/v1/meetings/{uuid}/lock")
+    @PatchMapping("/api/v1/meetings/{uuid}/lock")
     public void lock(@PathVariable String uuid, @AuthAttendee long id) {
         meetingService.lock(uuid, id);
     }

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -3,6 +3,7 @@ package kr.momo.controller.meeting;
 import jakarta.validation.Valid;
 import java.net.URI;
 import kr.momo.controller.MomoApiResponse;
+import kr.momo.controller.auth.AuthAttendee;
 import kr.momo.service.meeting.MeetingService;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingResponse;
@@ -40,5 +41,10 @@ public class MeetingController {
     public MomoApiResponse<MeetingSharingResponse> findMeetingSharing(@PathVariable String uuid) {
         MeetingSharingResponse response = meetingService.findMeetingSharing(uuid);
         return new MomoApiResponse<>(response);
+    }
+
+    @PostMapping("/api/v1/meetings/{uuid}/lock")
+    public void lock(@PathVariable String uuid, @AuthAttendee long id) {
+        meetingService.lock(uuid, id);
     }
 }

--- a/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
@@ -55,7 +55,7 @@ public class Attendee extends BaseEntity {
         this(meeting, new AttendeeName(name), new AttendeePassword(password), role);
     }
 
-    public boolean hasPermission() {
+    public boolean isHost() {
         return role.isHost();
     }
 

--- a/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
@@ -55,6 +55,10 @@ public class Attendee extends BaseEntity {
         this(meeting, new AttendeeName(name), new AttendeePassword(password), role);
     }
 
+    public boolean hasPermission() {
+        return role.isHost();
+    }
+
     public void verifyPassword(AttendeePassword other) {
         this.password.verifyPassword(other);
     }

--- a/backend/src/main/java/kr/momo/domain/attendee/Role.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/Role.java
@@ -1,6 +1,11 @@
 package kr.momo.domain.attendee;
 
 public enum Role {
+
     HOST,
-    GUEST
+    GUEST;
+
+    public boolean isHost() {
+        return HOST.equals(this);
+    }
 }

--- a/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
@@ -11,6 +11,8 @@ import java.time.LocalTime;
 import kr.momo.domain.BaseEntity;
 import kr.momo.domain.timeslot.Timeslot;
 import kr.momo.domain.timeslot.TimeslotInterval;
+import kr.momo.exception.MomoException;
+import kr.momo.exception.code.MeetingErrorCode;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,6 +33,9 @@ public class Meeting extends BaseEntity {
     @Column(nullable = false, length = 40)
     private String uuid;
 
+    @Column(nullable = false)
+    private boolean isLocked;
+
     @Embedded
     private TimeslotInterval timeslotInterval;
 
@@ -38,6 +43,14 @@ public class Meeting extends BaseEntity {
         this.name = name;
         this.uuid = uuid;
         this.timeslotInterval = new TimeslotInterval(firstTime, lastTime.minusMinutes(30));
+        this.isLocked = false;
+    }
+
+    public void lock() {
+        if (this.isLocked) {
+            throw new MomoException(MeetingErrorCode.ALREADY_LOCKED);
+        }
+        this.isLocked = true;
     }
 
     public Timeslot getValidatedTimeslot(LocalTime other) {

--- a/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
@@ -11,8 +11,6 @@ import java.time.LocalTime;
 import kr.momo.domain.BaseEntity;
 import kr.momo.domain.timeslot.Timeslot;
 import kr.momo.domain.timeslot.TimeslotInterval;
-import kr.momo.exception.MomoException;
-import kr.momo.exception.code.MeetingErrorCode;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,9 +45,6 @@ public class Meeting extends BaseEntity {
     }
 
     public void lock() {
-        if (this.isLocked) {
-            throw new MomoException(MeetingErrorCode.ALREADY_LOCKED);
-        }
         this.isLocked = true;
     }
 

--- a/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
@@ -8,7 +8,8 @@ public enum AttendeeErrorCode implements ErrorCodeType {
     INVALID_PASSWORD_LENGTH(HttpStatus.BAD_REQUEST, "비밀번호 길이는 최대 20글자까지 가능합니다."),
     PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_ATTENDEE(HttpStatus.BAD_REQUEST, "해당 약속에 참여하는 참가자 정보가 없습니다."),
-    NOT_FOUND_ATTENDEE(HttpStatus.NOT_FOUND, "해당 약속에 참여하는 참가자 정보가 없습니다.");
+    NOT_FOUND_ATTENDEE(HttpStatus.NOT_FOUND, "해당 약속에 참여하는 참가자 정보가 없습니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
@@ -6,7 +6,8 @@ public enum MeetingErrorCode implements ErrorCodeType {
 
     INVALID_UUID(HttpStatus.BAD_REQUEST, "유효하지 않은 UUID 입니다."),
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, "존재하지 않는 약속 정보 입니다."),
-    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "끝 시간은 시작 시간 이후가 되어야 합니다.");
+    INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "끝 시간은 시작 시간 이후가 되어야 합니다."),
+    ALREADY_LOCKED(HttpStatus.BAD_REQUEST, "이미 잠겨있는 약속입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
@@ -7,7 +7,7 @@ public enum MeetingErrorCode implements ErrorCodeType {
     INVALID_UUID(HttpStatus.BAD_REQUEST, "유효하지 않은 UUID 입니다."),
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, "존재하지 않는 약속 정보 입니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "끝 시간은 시작 시간 이후가 되어야 합니다."),
-    ALREADY_LOCKED(HttpStatus.BAD_REQUEST, "이미 잠겨있는 약속입니다.");
+    MEETING_LOCKED(HttpStatus.BAD_REQUEST, "약속이 잠겨있어 수행할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -12,6 +12,7 @@ import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
 import kr.momo.domain.meeting.MeetingRepository;
 import kr.momo.exception.MomoException;
+import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingResponse;
@@ -66,5 +67,21 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
         return MeetingSharingResponse.from(meeting);
+    }
+
+    @Transactional
+    public void lock(String uuid, long id) {
+        Meeting meeting = meetingRepository.findByUuid(uuid)
+                .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
+        Attendee attendee = attendeeRepository.findByIdAndMeeting(id, meeting)
+                .orElseThrow(() -> new MomoException(AttendeeErrorCode.NOT_FOUND_ATTENDEE));
+        validateAttendeePermission(attendee);
+        meeting.lock();
+    }
+
+    private void validateAttendeePermission(Attendee attendee) {
+        if (!attendee.hasPermission()) {
+            throw new MomoException(AttendeeErrorCode.ACCESS_DENIED);
+        }
     }
 }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -75,12 +75,12 @@ public class MeetingService {
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
         Attendee attendee = attendeeRepository.findByIdAndMeeting(id, meeting)
                 .orElseThrow(() -> new MomoException(AttendeeErrorCode.NOT_FOUND_ATTENDEE));
-        validateAttendeePermission(attendee);
+        validateHostPermission(attendee);
         meeting.lock();
     }
 
-    private void validateAttendeePermission(Attendee attendee) {
-        if (!attendee.hasPermission()) {
+    private void validateHostPermission(Attendee attendee) {
+        if (!attendee.isHost()) {
             throw new MomoException(AttendeeErrorCode.ACCESS_DENIED);
         }
     }

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.availabledate.AvailableDate;
 import kr.momo.domain.availabledate.AvailableDates;
@@ -15,6 +14,7 @@ public record MeetingResponse(
         String meetingName,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") LocalTime firstTime,
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul") LocalTime lastTime,
+        boolean isLocked,
         List<LocalDate> availableDates,
         List<String> attendeeNames
 ) {
@@ -22,7 +22,7 @@ public record MeetingResponse(
     public static MeetingResponse of(Meeting meeting, AvailableDates availableDates, List<Attendee> attendees) {
         List<LocalDate> dates = availableDates.getAvailableDates().stream()
                 .map(AvailableDate::getDate)
-                .collect(Collectors.toList());
+                .toList();
 
         List<String> attendeeNames = attendees.stream()
                 .map(Attendee::name)
@@ -32,6 +32,7 @@ public record MeetingResponse(
                 meeting.getName(),
                 meeting.startTimeslotTime(),
                 meeting.endTimeslotTime(),
+                meeting.isLocked(),
                 dates,
                 attendeeNames
         );

--- a/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
@@ -39,7 +39,7 @@ public class ScheduleService {
     public void create(String uuid, long attendeeId, ScheduleCreateRequest request) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
-        validateMeetingLocked(meeting);
+        validateMeetingUnLocked(meeting);
 
         Attendee attendee = attendeeRepository.findByIdAndMeeting(attendeeId, meeting)
                 .orElseThrow(() -> new MomoException(AttendeeErrorCode.INVALID_ATTENDEE));
@@ -49,7 +49,7 @@ public class ScheduleService {
         scheduleRepository.saveAll(schedules);
     }
 
-    private void validateMeetingLocked(Meeting meeting) {
+    private void validateMeetingUnLocked(Meeting meeting) {
         if (meeting.isLocked()) {
             throw new MomoException(MeetingErrorCode.MEETING_LOCKED);
         }

--- a/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
@@ -51,7 +51,7 @@ public class ScheduleService {
 
     private void validateMeetingLocked(Meeting meeting) {
         if (meeting.isLocked()) {
-            throw new MomoException(MeetingErrorCode.ALREADY_LOCKED);
+            throw new MomoException(MeetingErrorCode.MEETING_LOCKED);
         }
     }
 

--- a/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
@@ -39,12 +39,20 @@ public class ScheduleService {
     public void create(String uuid, long attendeeId, ScheduleCreateRequest request) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
+        validateMeetingLocked(meeting);
+
         Attendee attendee = attendeeRepository.findByIdAndMeeting(attendeeId, meeting)
                 .orElseThrow(() -> new MomoException(AttendeeErrorCode.INVALID_ATTENDEE));
 
         scheduleRepository.deleteAllByAttendee(attendee);
         List<Schedule> schedules = createSchedules(request, meeting, attendee);
         scheduleRepository.saveAll(schedules);
+    }
+
+    private void validateMeetingLocked(Meeting meeting) {
+        if (meeting.isLocked()) {
+            throw new MomoException(MeetingErrorCode.ALREADY_LOCKED);
+        }
     }
 
     private List<Schedule> createSchedules(ScheduleCreateRequest request, Meeting meeting, Attendee attendee) {

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -164,7 +164,7 @@ class MeetingControllerTest {
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", meeting.getUuid())
                 .header("Authorization", "Bearer " + token)
-                .when().post("/api/v1/meetings/{uuid}/lock")
+                .when().patch("/api/v1/meetings/{uuid}/lock")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
     }
@@ -189,7 +189,7 @@ class MeetingControllerTest {
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", invalidUUID)
                 .header("Authorization", "Bearer " + token)
-                .when().post("/api/v1/meetings/{uuid}/lock")
+                .when().patch("/api/v1/meetings/{uuid}/lock")
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());
     }
@@ -213,40 +213,8 @@ class MeetingControllerTest {
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", meeting.getUuid())
                 .header("Authorization", "Bearer " + token)
-                .when().post("/api/v1/meetings/{uuid}/lock")
+                .when().patch("/api/v1/meetings/{uuid}/lock")
                 .then().log().all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
-    }
-
-    @DisplayName("약속을 중복으로 잠그면 400을 반환한다.")
-    @Test
-    void lockWithDuplicatedRequest() {
-        Meeting meeting = meetingRepository.save(MeetingFixture.DINNER.create());
-        Attendee attendee = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
-        AttendeeLoginRequest request = new AttendeeLoginRequest(attendee.name(), attendee.password());
-
-        String token = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().jsonPath().getString("data.token");
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .pathParam("uuid", meeting.getUuid())
-                .header("Authorization", "Bearer " + token)
-                .when().post("/api/v1/meetings/{uuid}/lock")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value());
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .pathParam("uuid", meeting.getUuid())
-                .header("Authorization", "Bearer " + token)
-                .when().post("/api/v1/meetings/{uuid}/lock")
-                .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -169,7 +169,7 @@ class MeetingControllerTest {
                 .statusCode(HttpStatus.OK.value());
     }
 
-    @DisplayName("약속을 잠글 때 만남이 존재하지 않으면 404를 반환한다.")
+    @DisplayName("존재하지 않는 약속을 잠금 시도하면 404 Not Found를 반환한다.")
     @Test
     void lockWithInvalidUUID() {
         String invalidUUID = "INVALID_UUID";

--- a/backend/src/test/java/kr/momo/domain/attendee/RoleTest.java
+++ b/backend/src/test/java/kr/momo/domain/attendee/RoleTest.java
@@ -1,0 +1,17 @@
+package kr.momo.domain.attendee;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class RoleTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {"HOST,true", "GUEST,false"})
+    void isHost(Role given, boolean expected) {
+        boolean result = given.isHost();
+
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.LocalTime;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.MeetingErrorCode;
+import kr.momo.fixture.MeetingFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -62,5 +63,26 @@ class MeetingTest {
 
         // then
         assertThat(meeting.endTimeslotTime()).isEqualTo(endTime.minusMinutes(30));
+    }
+
+    @DisplayName("약속을 잠근다.")
+    @Test
+    void lock() {
+        Meeting meeting = MeetingFixture.DINNER.create();
+
+        meeting.lock();
+
+        assertThat(meeting.isLocked()).isTrue();
+    }
+
+    @DisplayName("약속이 잠겨있는데 잠금을 요청하면 예외가 발생한다.")
+    @Test
+    void throwExceptionWhenLocked() {
+        Meeting meeting = MeetingFixture.DINNER.create();
+        meeting.lock();
+
+        assertThatThrownBy(meeting::lock)
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.ALREADY_LOCKED.message());
     }
 }

--- a/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
@@ -74,15 +74,4 @@ class MeetingTest {
 
         assertThat(meeting.isLocked()).isTrue();
     }
-
-    @DisplayName("약속이 잠겨있는데 잠금을 요청하면 예외가 발생한다.")
-    @Test
-    void throwExceptionWhenLocked() {
-        Meeting meeting = MeetingFixture.DINNER.create();
-        meeting.lock();
-
-        assertThatThrownBy(meeting::lock)
-                .isInstanceOf(MomoException.class)
-                .hasMessage(MeetingErrorCode.MEETING_LOCKED.message());
-    }
 }

--- a/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
@@ -83,6 +83,6 @@ class MeetingTest {
 
         assertThatThrownBy(meeting::lock)
                 .isInstanceOf(MomoException.class)
-                .hasMessage(MeetingErrorCode.ALREADY_LOCKED.message());
+                .hasMessage(MeetingErrorCode.MEETING_LOCKED.message());
     }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -14,6 +14,7 @@ import kr.momo.domain.availabledate.AvailableDateRepository;
 import kr.momo.domain.meeting.Meeting;
 import kr.momo.domain.meeting.MeetingRepository;
 import kr.momo.exception.MomoException;
+import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.AvailableDateErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.fixture.AttendeeFixture;
@@ -104,5 +105,55 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.create(request))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
+    }
+
+    @DisplayName("약속을 잠그면 잠금 상태가 변경된다.")
+    @Test
+    void lock() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.GAME.create());
+        Attendee attendee = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
+
+        meetingService.lock(meeting.getUuid(), attendee.getId());
+        Meeting changedMeeting = meetingRepository.findById(meeting.getId()).orElseThrow();
+
+        assertThat(changedMeeting.isLocked()).isTrue();
+    }
+
+    @DisplayName("약속을 잠글 때 약속을 조회할 수 없다면 예외가 발생한다.")
+    @Test
+    void throwsExceptionWhenNoMeeting() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.GAME.create());
+        Attendee attendee = attendeeRepository.save(AttendeeFixture.GUEST_PEDRO.create(meeting));
+        String uuid = "";
+        long id = attendee.getId();
+
+        assertThatThrownBy(() -> meetingService.lock(uuid, id))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.NOT_FOUND_MEETING.message());
+    }
+
+    @DisplayName("약속을 잠글 때 참가자가 존재하지 않다면 예외가 발생한다.")
+    @Test
+    void throwsExceptionWhenNoAttendee() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.GAME.create());
+        String uuid = meeting.getUuid();
+        long id = 1L;
+
+        assertThatThrownBy(() -> meetingService.lock(uuid, id))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(AttendeeErrorCode.NOT_FOUND_ATTENDEE.message());
+    }
+
+    @DisplayName("약속을 잠글 때 로그인된 참가자가 호스트가 아니면 예외가 발생한다.")
+    @Test
+    void throwsExceptionWhenAttendeeGuest() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.GAME.create());
+        Attendee attendee = attendeeRepository.save(AttendeeFixture.GUEST_PEDRO.create(meeting));
+        String uuid = meeting.getUuid();
+        long id = attendee.getId();
+
+        assertThatThrownBy(() -> meetingService.lock(uuid, id))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(AttendeeErrorCode.ACCESS_DENIED.message());
     }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -2,7 +2,7 @@ package kr.momo.service.meeting;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -57,13 +57,14 @@ class MeetingServiceTest {
 
         MeetingResponse response = meetingService.findByUUID(meeting.getUuid());
 
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(response.firstTime()).isEqualTo(meeting.startTimeslotTime());
-            softAssertions.assertThat(response.lastTime()).isEqualTo(meeting.endTimeslotTime());
-            softAssertions.assertThat(response.meetingName()).isEqualTo(meeting.getName());
-            softAssertions.assertThat(response.availableDates().size()).isEqualTo(availableDates.size());
-            softAssertions.assertThat(response.attendeeNames()).isEqualTo(List.of(attendee.name()));
-        });
+        assertAll(
+                () -> assertThat(response.firstTime()).isEqualTo(meeting.startTimeslotTime()),
+                () -> assertThat(response.lastTime()).isEqualTo(meeting.endTimeslotTime()),
+                () -> assertThat(response.meetingName()).isEqualTo(meeting.getName()),
+                () -> assertThat(response.isLocked()).isFalse(),
+                () -> assertThat(response.availableDates()).hasSize(availableDates.size()),
+                () -> assertThat(response.attendeeNames()).isEqualTo(List.of(attendee.name()))
+        );
     }
 
     @DisplayName("생성 완료된 약속의 정보를 조회한다.")

--- a/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
@@ -76,14 +76,30 @@ class ScheduleServiceTest {
         );
     }
 
+    @DisplayName("스케줄 생성 시 사용자의 기존 스케줄들을 모두 삭제하고 새로운 스케줄을 저장한다.")
+    @Test
+    void createSchedulesReplacesOldSchedules() {
+        ScheduleCreateRequest request = new ScheduleCreateRequest(attendee.name(), dateTimes);
+        scheduleRepository.saveAll(List.of(
+                new Schedule(attendee, today, Timeslot.TIME_0130),
+                new Schedule(attendee, tomorrow, Timeslot.TIME_0130)
+        ));
+
+        scheduleService.create(meeting.getUuid(), attendee.getId(), request);
+        long scheduleCount = scheduleRepository.count();
+
+        assertThat(scheduleCount).isEqualTo(4);
+    }
+
     @DisplayName("스케줄 생성 요청의 UUID가 존재하지 않으면 예외를 발생시킨다.")
     @Test
     void throwsExceptionWhenInvalidUUID() {
         Meeting other = MeetingFixture.DINNER.create();
+        String invalidUUID = other.getUuid();
         long attendeeId = attendee.getId();
         ScheduleCreateRequest request = new ScheduleCreateRequest(attendee.name(), dateTimes);
 
-        assertThatThrownBy(() -> scheduleService.create(other.getUuid(), attendeeId, request))
+        assertThatThrownBy(() -> scheduleService.create(invalidUUID, attendeeId, request))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(MeetingErrorCode.INVALID_UUID.message());
     }
@@ -101,19 +117,19 @@ class ScheduleServiceTest {
                 .hasMessage(AttendeeErrorCode.INVALID_ATTENDEE.message());
     }
 
-    @DisplayName("스케줄 생성 시 사용자의 기존 스케줄들을 모두 삭제하고 새로운 스케줄을 저장한다.")
+    @DisplayName("스케줄 생성시 약속이 잠겨있다면 예외를 발생시킨다.")
     @Test
-    void createSchedulesReplacesOldSchedules() {
+    void throwsExceptionWhenMeetingLocked() {
+        Meeting game = MeetingFixture.GAME.create();
+        game.lock();
+        Meeting lockedMeeting = meetingRepository.save(game);
         ScheduleCreateRequest request = new ScheduleCreateRequest(attendee.name(), dateTimes);
-        scheduleRepository.saveAll(List.of(
-                new Schedule(attendee, today, Timeslot.TIME_0130),
-                new Schedule(attendee, tomorrow, Timeslot.TIME_0130)
-        ));
+        String givenUUID = lockedMeeting.getUuid();
+        Long givenAttendeeId = attendee.getId();
 
-        scheduleService.create(meeting.getUuid(), attendee.getId(), request);
-        long scheduleCount = scheduleRepository.count();
-
-        assertThat(scheduleCount).isEqualTo(4);
+        assertThatThrownBy(() -> scheduleService.create(givenUUID, givenAttendeeId, request))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.ALREADY_LOCKED.message());
     }
 
     /* dummy data table

--- a/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
@@ -129,7 +129,7 @@ class ScheduleServiceTest {
 
         assertThatThrownBy(() -> scheduleService.create(givenUUID, givenAttendeeId, request))
                 .isInstanceOf(MomoException.class)
-                .hasMessage(MeetingErrorCode.ALREADY_LOCKED.message());
+                .hasMessage(MeetingErrorCode.MEETING_LOCKED.message());
     }
 
     /* dummy data table


### PR DESCRIPTION
## 관련 이슈

- resolves: #112 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- 약속 필드 내 `boolean` 타입의 잠금 여부를 추가하였습니다.
- 기존 스케줄 생성시 약속이 잠금일 경우 예외가 발생하도록 검증을 추가하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- 해당 PR이 머지되면 잠금 취소 기능도 추가할 예정입니다.

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

> 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요?

`Meeting` 객체 내 중복된 잠금 시도시 예외가 발생하도록 로직이 짜여져있는데요.
불필요한 검증일지 궁금합니다!