### PR TITLE
[FE] colors, typography 디자인 토큰 생성

### DIFF
--- a/frontend/src/components/_common/Button/Button.styles.ts
+++ b/frontend/src/components/_common/Button/Button.styles.ts
@@ -21,7 +21,7 @@ export const s_button = css`
   box-shadow: 0 3px 6px rgb(0 0 0 / 20%);
 
   &:hover {
-    color: #fff;
+    color: ${theme.colors.white};
     background: ${theme.colors.primary};
     border: none;
   }

--- a/frontend/src/components/_common/Button/Button.styles.ts
+++ b/frontend/src/components/_common/Button/Button.styles.ts
@@ -13,16 +13,16 @@ export const s_button = css`
   padding: 0.4rem 3rem;
 
   font-weight: 700;
-  color: ${theme.color.primary};
+  color: ${theme.colors.primary};
 
   background: #fff;
-  border: 1px solid ${theme.color.primary};
+  border: 1px solid ${theme.colors.primary};
   border-radius: 8px;
   box-shadow: 0 3px 6px rgb(0 0 0 / 20%);
 
   &:hover {
     color: #fff;
-    background: ${theme.color.primary};
+    background: ${theme.colors.primary};
     border: none;
   }
 `;

--- a/frontend/src/components/_common/Calendar/Calendar.styles.ts
+++ b/frontend/src/components/_common/Calendar/Calendar.styles.ts
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 
+import theme from '@styles/theme';
+
 export const s_calendarContainer = css`
   display: flex;
   flex-direction: column;
@@ -67,7 +69,7 @@ export const s_daySlotButton = css`
 export const s_daySlot = (isHoliday: boolean) => css`
   cursor: pointer;
   font-size: 1.5rem;
-  color: ${isHoliday ? 'red' : '#000'};
+  color: ${isHoliday ? theme.colors.holiday : theme.colors.black};
 `;
 
 export const s_selectedDaySlot = (isSelected: boolean) => css`

--- a/frontend/src/components/_common/TimeSlot/TimeSlot.styles.ts
+++ b/frontend/src/components/_common/TimeSlot/TimeSlot.styles.ts
@@ -10,7 +10,7 @@ export const s_td = (isSelected: boolean, isUpdate: boolean) => css`
 
   color: ${isSelected ? '#121010' : '#fff'};
 
-  background: ${isSelected ? theme.colors.primary : '#ececec'};
+  background: ${isSelected ? theme.colors.primary : theme.colors.grey.primary};
   border-radius: 0.4rem;
 
   &:hover {

--- a/frontend/src/components/_common/TimeSlot/TimeSlot.styles.ts
+++ b/frontend/src/components/_common/TimeSlot/TimeSlot.styles.ts
@@ -10,7 +10,7 @@ export const s_td = (isSelected: boolean, isUpdate: boolean) => css`
 
   color: ${isSelected ? '#121010' : '#fff'};
 
-  background: ${isSelected ? theme.linear.selectedTime : '#ececec'};
+  background: ${isSelected ? theme.colors.primary : '#ececec'};
   border-radius: 0.4rem;
 
   &:hover {

--- a/frontend/src/pages/CreateMeetingPage/CreateMeetingPage.styles.ts
+++ b/frontend/src/pages/CreateMeetingPage/CreateMeetingPage.styles.ts
@@ -29,13 +29,13 @@ export const s_confirm = css`
   font-weight: 800;
   color: #fff;
 
-  background: ${theme.color.primary};
+  background: ${theme.colors.primary};
   border: none;
   border-radius: 8px;
 
   &:hover {
-    color: ${theme.color.primary};
+    color: ${theme.colors.primary};
     background: #fff;
-    border: 1px solid ${theme.color.primary};
+    border: 1px solid ${theme.colors.primary};
   }
 `;

--- a/frontend/src/pages/MeetingTimePickPage/MeetingTimePickPage.styles.ts
+++ b/frontend/src/pages/MeetingTimePickPage/MeetingTimePickPage.styles.ts
@@ -57,7 +57,7 @@ export const s_tabButton = (isSelected: boolean) => css`
   ${isSelected
     ? css`
         color: #fff;
-        background-color: ${theme.color.primary};
+        background-color: ${theme.colors.primary};
       `
     : css`
         color: #6d7580;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,28 +1,11 @@
 import type { Theme } from '@emotion/react';
 
+import { SEMANTIC_COLORS } from './tokens/colors';
+import TYPOGRAPHY from './tokens/typography';
+
 const theme: Theme = {
-  color: {
-    primary: '#ff8da6',
-    holiday: '#ff0000',
-    primaryUnselected: '#f0f0f0',
-  },
-  linear: {
-    selectedTime: 'linear-gradient(180deg, rgba(248, 170, 130, 0.3) 0%, #FFADBF 100%)',
-  },
-  fontWeight: {
-    light: 300,
-    normal: 400,
-    medium: 500,
-    bold: 700,
-    extraBold: 800,
-  },
-  fontSize: {
-    xs: '1.2rem',
-    small: '1.4rem',
-    medium: '1.6rem',
-    large: '2rem',
-    xl: '2.4rem',
-  },
+  colors: SEMANTIC_COLORS,
+  typography: TYPOGRAPHY,
 };
 
 export default theme;

--- a/frontend/src/styles/tokens/colors.ts
+++ b/frontend/src/styles/tokens/colors.ts
@@ -1,0 +1,58 @@
+const PRIMITIVE_COLORS = {
+  black: '#000000',
+  white: '#ffffff',
+  pink: {
+    100: '#FFEBE8',
+    200: '#FFD4D1',
+    300: '#FFBABC',
+    400: '#FFA9B4',
+    500: '#FF8DA6',
+    600: '#DB678B',
+    700: '#B74775',
+    800: '#932C61',
+    900: '#7A1B54',
+  },
+  grey: {
+    100: '#f4f4f5',
+    200: '#e4e4e7',
+    300: '#d4d4d8',
+    400: '#a1a1aa',
+    500: '#71717a',
+    600: '#52525b',
+    700: '#3f3f46',
+    800: '#27272a',
+    900: '#18181b',
+  },
+  // 현재 달력에서 공휴일 색을 표시하기 위해서 빨간색을 사용하고 있는데, 빨간색도 palette를 사용해야 할지는 미정(@해리)
+  red: {
+    100: '#ff0000',
+  },
+} as const;
+
+export const SEMANTIC_COLORS = {
+  white: PRIMITIVE_COLORS.white,
+  black: PRIMITIVE_COLORS.black,
+  primary: PRIMITIVE_COLORS.pink['300'],
+  holiday: PRIMITIVE_COLORS.red['100'],
+  grey: {
+    primary: PRIMITIVE_COLORS.grey['200'],
+    dark: PRIMITIVE_COLORS.grey['500'],
+  },
+  timeTable: {
+    unselected: {
+      light: PRIMITIVE_COLORS.grey['200'],
+      dark: PRIMITIVE_COLORS.grey['500'],
+    },
+    selected: {
+      light: PRIMITIVE_COLORS.pink['100'],
+      mediumLight: PRIMITIVE_COLORS.pink['200'],
+      medium: PRIMITIVE_COLORS.pink['300'],
+      mediumDark: PRIMITIVE_COLORS.pink['400'],
+      dark: PRIMITIVE_COLORS.pink['500'],
+      darker: PRIMITIVE_COLORS.pink['600'],
+      darkest: PRIMITIVE_COLORS.pink['700'],
+      deep: PRIMITIVE_COLORS.pink['800'],
+      deepDark: PRIMITIVE_COLORS.pink['900'],
+    },
+  },
+};

--- a/frontend/src/styles/tokens/colors.ts
+++ b/frontend/src/styles/tokens/colors.ts
@@ -1,6 +1,9 @@
 const PRIMITIVE_COLORS = {
   black: '#000000',
   white: '#ffffff',
+  // 현재 달력에서 공휴일 색을 표시하기 위해서 빨간색을 사용하고 있는데, 빨간색도 palette를 사용해야 할지는 미정(@해리)
+  red: '#ff0000',
+
   pink: {
     100: '#FFEBE8',
     200: '#FFD4D1',
@@ -23,17 +26,13 @@ const PRIMITIVE_COLORS = {
     800: '#27272a',
     900: '#18181b',
   },
-  // 현재 달력에서 공휴일 색을 표시하기 위해서 빨간색을 사용하고 있는데, 빨간색도 palette를 사용해야 할지는 미정(@해리)
-  red: {
-    100: '#ff0000',
-  },
 } as const;
 
 export const SEMANTIC_COLORS = {
   white: PRIMITIVE_COLORS.white,
   black: PRIMITIVE_COLORS.black,
   primary: PRIMITIVE_COLORS.pink['300'],
-  holiday: PRIMITIVE_COLORS.red['100'],
+  holiday: PRIMITIVE_COLORS.red,
   grey: {
     primary: PRIMITIVE_COLORS.grey['200'],
     dark: PRIMITIVE_COLORS.grey['500'],
@@ -55,4 +54,4 @@ export const SEMANTIC_COLORS = {
       deepDark: PRIMITIVE_COLORS.pink['900'],
     },
   },
-};
+} as const;

--- a/frontend/src/styles/tokens/typography.ts
+++ b/frontend/src/styles/tokens/typography.ts
@@ -1,0 +1,71 @@
+import type { CSSProperties } from 'react';
+
+type FontWeightKey = 'bold' | 'medium' | 'regular' | 'light';
+
+const FontWeight: Record<FontWeightKey, CSSProperties['fontWeight']> = {
+  bold: 700,
+  medium: 500,
+  regular: 400,
+  light: 300,
+};
+
+const TYPOGRAPHY = {
+  // title -> subtitle -> body -> caption
+  titleBold: {
+    fontSize: '2.4rem',
+    fontWeight: FontWeight['bold'],
+    lineHeight: '1.5',
+  },
+  titleMedium: {
+    fontSize: '2.4rem',
+    fontWeight: FontWeight['medium'],
+    lineHeight: '1.5',
+  },
+  subTitleBold: {
+    fontSize: '2.0rem',
+    fontWeight: FontWeight['bold'],
+    lineHeight: '1.5',
+  },
+  subTitleMedium: {
+    fontSize: '2.0rem',
+    fontWeight: FontWeight['medium'],
+    lineHeight: '1.5',
+  },
+  subTitleLight: {
+    fontSize: '2.0rem',
+    fontWeight: FontWeight['light'],
+    lineHeight: '1.5',
+  },
+  bodyBold: {
+    fontSize: '1.6rem',
+    fontWeight: FontWeight['bold'],
+    lineHeight: '1.5',
+  },
+  bodyMedium: {
+    fontSize: '1.6rem',
+    fontWeight: FontWeight['medium'],
+    lineHeight: '1.5',
+  },
+  bodyLight: {
+    fontSize: '1.6rem',
+    fontWeight: FontWeight['light'],
+    lineHeight: '1.5',
+  },
+  captionBold: {
+    fontSize: '1.2rem',
+    fontWeight: FontWeight['bold'],
+    lineHeight: '1.3',
+  },
+  captionMedium: {
+    fontSize: '1.2rem',
+    fontWeight: FontWeight['medium'],
+    lineHeight: '1.3',
+  },
+  captionLight: {
+    fontSize: '1.2rem',
+    fontWeight: FontWeight['light'],
+    lineHeight: '1.3',
+  },
+};
+
+export default TYPOGRAPHY;

--- a/frontend/src/types/styles/theme.d.ts
+++ b/frontend/src/types/styles/theme.d.ts
@@ -1,28 +1,11 @@
 import '@emotion/react';
 
+import type { SEMANTIC_COLORS } from '@styles/tokens/colors';
+import type TYPOGRAPHY from '@styles/tokens/typographys';
+
 declare module '@emotion/react' {
   export interface Theme {
-    color: {
-      primary: string;
-      holiday: string;
-      primaryUnselected: string;
-    };
-    linear: {
-      selectedTime: string;
-    };
-    fontWeight: {
-      light: number;
-      normal: number;
-      medium: number;
-      bold: number;
-      extraBold: number;
-    };
-    fontSize: {
-      xs: string;
-      small: string;
-      medium: string;
-      large: string;
-      xl: string;
-    };
+    colors: typeof SEMANTIC_COLORS;
+    typography: typeof TYPOGRAPHY;
   }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #124 

## 작업 내용

### 디자인 토큰 적용

- colors
- typography
  - 피그마에 있는 값들은 모바일 규격과 맞지 않다고 판단했어요.
  - 그래서 `title`의 `font-size`를 `2.4rem`으로 잡고, title -> subtitle -> body -> caption 순으로 `0.4rem` 씩 내리면서 스타일을 설정했습니다.
  - font-size, font-weight, line-height를 함께 설정했어요
- timetable
  - 선택된 색상과, 선택되지 않은 색상을 구분하기 위해서 `selected`, `unselected` 프로퍼티를 추가하여 구분했어요.
  - `unselected` 같은 경우 피그마 디자인과 약간 색이 달라요. 
    - `dark` 색상은 사용자가 시간을 수정할 때, 선택한 시간과 더 대비되도록 하기 위해서 어둡게 할 때 사용하면 될 것 같아요

## 특이 사항

- 변경된 `grey` 팔레트 색상 피그마에 적용 예정
- 변경된 `typography` 피그마에 적용 예정
- red 색상에 관해서 추가 논의 필요

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
