### PR TITLE
[BE] 기존 jwt 토큰 응답 방식을 쿠키로 변경하고 path 및 보안 설정

### DIFF
--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
@@ -1,11 +1,12 @@
 package kr.momo.controller.attendee;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import kr.momo.service.attendee.AttendeeService;
 import kr.momo.service.attendee.dto.AttendeeLoginRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,21 +21,21 @@ public class AttendeeController {
     private final AttendeeService attendeeService;
 
     @PostMapping("/api/v1/meetings/{uuid}/login")
-    public void login(
-            @PathVariable String uuid, @RequestBody @Valid AttendeeLoginRequest request, HttpServletResponse response
-    ) {
+    public ResponseEntity<Void> login(@PathVariable String uuid, @RequestBody @Valid AttendeeLoginRequest request) {
         String token = attendeeService.login(uuid, request);
         String path = String.format("/api/v1/meetings/%s/", uuid);
 
-        Cookie cookie = createCookie(token, path);
-        response.addCookie(cookie);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, createCookie(token, path))
+                .build();
     }
 
-    private Cookie createCookie(String value, String path) {
-        Cookie cookie = new Cookie(ACCESS_TOKEN, value);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath(path);
-        return cookie;
+    private String createCookie(String value, String path) {
+        return ResponseCookie.from(ACCESS_TOKEN, value)
+                .httpOnly(true)
+                .secure(true)
+                .path(path)
+                .build()
+                .toString();
     }
 }

--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
@@ -1,10 +1,10 @@
 package kr.momo.controller.attendee;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import kr.momo.controller.MomoApiResponse;
 import kr.momo.service.attendee.AttendeeService;
 import kr.momo.service.attendee.dto.AttendeeLoginRequest;
-import kr.momo.service.attendee.dto.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,12 +15,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AttendeeController {
 
+    private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
+
     private final AttendeeService attendeeService;
 
     @PostMapping("/api/v1/meetings/{uuid}/login")
-    public MomoApiResponse<TokenResponse> login(
-            @PathVariable String uuid, @RequestBody @Valid AttendeeLoginRequest request
+    public void login(
+            @PathVariable String uuid, @RequestBody @Valid AttendeeLoginRequest request, HttpServletResponse response
     ) {
-        return new MomoApiResponse<>(attendeeService.login(uuid, request));
+        String token = attendeeService.login(uuid, request);
+        String path = String.format("/api/v1/meetings/%s/", uuid);
+
+        Cookie cookie = createCookie(token, path);
+        response.addCookie(cookie);
+    }
+
+    private Cookie createCookie(String value, String path) {
+        Cookie cookie = new Cookie(ACCESS_TOKEN, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath(path);
+        return cookie;
     }
 }

--- a/backend/src/main/java/kr/momo/controller/auth/AuthArgumentResolver.java
+++ b/backend/src/main/java/kr/momo/controller/auth/AuthArgumentResolver.java
@@ -3,8 +3,7 @@ package kr.momo.controller.auth;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
-import kr.momo.exception.MomoException;
-import kr.momo.exception.code.AuthErrorCode;
+import java.util.Optional;
 import kr.momo.service.auth.JwtManager;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -38,24 +37,19 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         Cookie[] cookies = request.getCookies();
-        String token = getCookieValue(cookies);
-
-        if (token == null) {
-            throw new MomoException(AuthErrorCode.NOT_FOUND_TOKEN);
-        }
+        String token = getCookieValue(cookies).orElse("");
 
         return jwtManager.extract(token);
     }
 
-    private String getCookieValue(Cookie[] cookies) {
+    private Optional<String> getCookieValue(Cookie[] cookies) {
         if (cookies == null) {
-            return null;
+            return Optional.empty();
         }
 
         return Arrays.stream(cookies)
                 .filter(cookie -> ACCESS_TOKEN.equals(cookie.getName()))
                 .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
+                .findFirst();
     }
 }

--- a/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
+++ b/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
@@ -10,7 +10,6 @@ import kr.momo.domain.meeting.MeetingRepository;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.service.attendee.dto.AttendeeLoginRequest;
-import kr.momo.service.attendee.dto.TokenResponse;
 import kr.momo.service.auth.JwtManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,7 +24,7 @@ public class AttendeeService {
     private final JwtManager jwtManager;
 
     @Transactional
-    public TokenResponse login(String uuid, AttendeeLoginRequest request) {
+    public String login(String uuid, AttendeeLoginRequest request) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
 
@@ -37,14 +36,14 @@ public class AttendeeService {
                 .orElseGet(() -> signup(meeting, name, password));
     }
 
-    private TokenResponse verifyPassword(Attendee attendee, AttendeePassword password) {
+    private String verifyPassword(Attendee attendee, AttendeePassword password) {
         attendee.verifyPassword(password);
-        return new TokenResponse(jwtManager.generate(attendee.getId()));
+        return jwtManager.generate(attendee.getId());
     }
 
-    private TokenResponse signup(Meeting meeting, AttendeeName name, AttendeePassword password) {
+    private String signup(Meeting meeting, AttendeeName name, AttendeePassword password) {
         Attendee attendee = new Attendee(meeting, name, password, Role.GUEST);
         attendeeRepository.save(attendee);
-        return new TokenResponse(jwtManager.generate(attendee.getId()));
+        return jwtManager.generate(attendee.getId());
     }
 }

--- a/backend/src/main/java/kr/momo/service/attendee/dto/TokenResponse.java
+++ b/backend/src/main/java/kr/momo/service/attendee/dto/TokenResponse.java
@@ -1,4 +1,0 @@
-package kr.momo.service.attendee.dto;
-
-public record TokenResponse(String token) {
-}

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -153,9 +153,9 @@ class MeetingControllerTest {
         String token = getToken(attendee, meeting);
 
         RestAssured.given().log().all()
+                .cookie("ACCESS_TOKEN", token)
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", meeting.getUuid())
-                .header("Authorization", "Bearer " + token)
                 .when().patch("/api/v1/meetings/{uuid}/lock")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -170,9 +170,9 @@ class MeetingControllerTest {
         String token = getToken(attendee, meeting);
 
         RestAssured.given().log().all()
+                .cookie("ACCESS_TOKEN", token)
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", invalidUUID)
-                .header("Authorization", "Bearer " + token)
                 .when().patch("/api/v1/meetings/{uuid}/lock")
                 .then().log().all()
                 .statusCode(HttpStatus.NOT_FOUND.value());
@@ -186,9 +186,9 @@ class MeetingControllerTest {
         String token = getToken(attendee, meeting);
 
         RestAssured.given().log().all()
+                .cookie("ACCESS_TOKEN", token)
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", meeting.getUuid())
-                .header("Authorization", "Bearer " + token)
                 .when().patch("/api/v1/meetings/{uuid}/lock")
                 .then().log().all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
@@ -202,9 +202,9 @@ class MeetingControllerTest {
         String token = getToken(attendee, meeting);
 
         RestAssured.given().log().all()
+                .cookie("ACCESS_TOKEN", token)
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", meeting.getUuid())
-                .header("Authorization", "Bearer " + token)
                 .when().patch("/api/v1/meetings/{uuid}/unlock")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
@@ -219,9 +219,9 @@ class MeetingControllerTest {
         String token = getToken(attendee, meeting);
 
         RestAssured.given().log().all()
+                .cookie("ACCESS_TOKEN", token)
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", invalidUUID)
-                .header("Authorization", "Bearer " + token)
                 .when().patch("/api/v1/meetings/{uuid}/unlock")
                 .then().log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
@@ -235,9 +235,9 @@ class MeetingControllerTest {
         String token = getToken(attendee, meeting);
 
         RestAssured.given().log().all()
+                .cookie("ACCESS_TOKEN", token)
                 .contentType(ContentType.JSON)
                 .pathParam("uuid", meeting.getUuid())
-                .header("Authorization", "Bearer " + token)
                 .when().patch("/api/v1/meetings/{uuid}/unlock")
                 .then().log().all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
@@ -252,6 +252,6 @@ class MeetingControllerTest {
                 .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .extract().jsonPath().getString("data.token");
+                .extract().cookie("ACCESS_TOKEN");
     }
 }

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -74,7 +74,7 @@ class ScheduleControllerTest {
                 .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .extract().jsonPath().getString("data.token");
+                .extract().cookie("ACCESS_TOKEN");
 
         List<LocalTime> times = List.of(Timeslot.TIME_0100.getLocalTime(), Timeslot.TIME_0130.getLocalTime());
         List<DateTimesCreateRequest> dateTimes = List.of(
@@ -85,7 +85,7 @@ class ScheduleControllerTest {
         ScheduleCreateRequest scheduleCreateRequest = new ScheduleCreateRequest(attendee.name(), dateTimes);
 
         RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + token)
+                .cookie("ACCESS_TOKEN", token)
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
                 .body(scheduleCreateRequest)
@@ -130,10 +130,10 @@ class ScheduleControllerTest {
                 .when().post("/api/v1/meetings/{uuid}/login", meeting.getUuid())
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
-                .extract().jsonPath().getString("data.token");
+                .extract().cookie("ACCESS_TOKEN");
 
         RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + token)
+                .cookie("ACCESS_TOKEN", token)
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
                 .when().get("/api/v1/meetings/{uuid}/attendees/me/schedules")

--- a/backend/src/test/java/kr/momo/service/auth/JwtManagerTest.java
+++ b/backend/src/test/java/kr/momo/service/auth/JwtManagerTest.java
@@ -12,6 +12,9 @@ import kr.momo.exception.code.AuthErrorCode;
 import kr.momo.fixture.MeetingFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JwtManagerTest {
 
@@ -30,11 +33,11 @@ class JwtManagerTest {
         assertThat(attendeeId).isEqualTo(attendee.getId());
     }
 
-    @DisplayName("토큰이 올바르지 않을 경우 예외를 발생시킨다.")
-    @Test
-    void throwExceptionForInvalidToken() {
-        String token = "invalidToken";
-
+    @DisplayName("토큰이 null이거나 올바르지 않을 경우 예외를 발생시킨다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"invalidToken"})
+    void throwExceptionForInvalidToken(String token) {
         assertThatThrownBy(() -> jwtManager.extract(token))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AuthErrorCode.INVALID_TOKEN.message());


### PR DESCRIPTION
## 관련 이슈

- resolves: #117 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- 응답 시 ResponseBody, 요청 시 Authorization 헤더에 jwt 토큰을 저장하던 방식을 쿠키로 변경하였습니다.
- 쿠키의 `HttpOnly`, `Secure` 옵션을 활성화 하였습니다.
- 요청시 현재 사용자가 접속한 UUID와 일치하는 인증 쿠키만 전송하도록 인증 쿠키 path에 약속 UUID를 포함하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
