### PR TITLE
[BE] SpringBoot 프로퍼티 분리, MySQL Server 연결

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -109,7 +109,7 @@ jobs:
 
       # 3. 도커 컨테이너 실행
       - name: docker run new container
-        run: docker run --name momo-api --rm -d -p 80:8080 --volume=$HOME/security:/security:ro ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
+        run: docker run --name momo-api --rm -d -p 80:8080 --volume=$HOME/security:/momo/security:ro ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
 
       # 4. 미사용 이미지를 정리
       - name: delete old docker image

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -109,7 +109,12 @@ jobs:
 
       # 3. 도커 컨테이너 실행
       - name: docker run new container
-        run: docker run --name momo-api --rm -d -p 80:8080 --volume=$HOME/security:/momo/security:ro ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
+        run: >-
+          docker run --name momo-api
+          --rm -d -p 80:8080
+          --volume=$HOME/security:/momo/security:ro
+          --env SPRING_PROFILE=dev
+          ${{ secrets.DOCKERHUB_USERNAME }}/momo-api
 
       # 4. 미사용 이미지를 정리
       - name: delete old docker image

--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,4 @@ gradle-app.setting
 
 ### BACKEND
 **/.idea
+backend/src/main/resources/property-override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -339,5 +339,4 @@ gradle-app.setting
 *.hprof
 
 ### BACKEND
-backend/src/main/resources/application.yml
 **/.idea

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,9 +2,10 @@ FROM --platform=linux/arm64 openjdk:17-ea-11
 
 ARG SECURITY_VOLUME=/momo/security
 ENV SECURITY_PATH=$SECURITY_VOLUME
+ENV SPRING_PROFILE=local
 
 COPY build/libs/*.jar /momo/momo-api.jar
-ENTRYPOINT [ "java", "-jar", "/momo/momo-api.jar", \
-    "--spring.profiles.active=dev" ]
+ENTRYPOINT ["java", "-jar", "/momo/momo-api.jar"]
+CMD ["--spring.profiles.active=${SPRING_PROFILE}"]
 
 EXPOSE 8080

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,10 @@
 FROM --platform=linux/arm64 openjdk:17-ea-11
 
-COPY build/libs/*.jar momo-api.jar
-ENTRYPOINT ["java","-jar","/momo-api.jar", "--spring.config.location=file:/security/"]
+ARG SECURITY_VOLUME=/momo/security
+ENV SECURITY_PATH=$SECURITY_VOLUME
+
+COPY build/libs/*.jar /momo/momo-api.jar
+ENTRYPOINT [ "java", "-jar", "/momo/momo-api.jar", \
+    "--spring.profiles.active=dev" ]
+
+EXPOSE 8080

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,10 +50,3 @@ test {
 bootJar {
     exclude('*.yml')
 }
-
-processResources.dependsOn('copyYML')
-tasks.register('copyYML', Copy) {
-    from 'src/main/resources/security' // 서브 모듈 경로
-    include "*.yml"
-    into 'src/main/resources'
-}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,5 +48,5 @@ test {
 }
 
 bootJar {
-    exclude('*.yml')
+    exclude('security/**')
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,13 @@
+spring:
+  config:
+    activate.on-profile: dev
+    import:
+      - ${SECURITY_PATH:classpath:security}/datasource-dev.yml
+      - ${SECURITY_PATH:classpath:security}/jwt.yml
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    activate.on-profile: local
+    import:
+      - classpath:datasource.yml
+  jpa:
+    hibernate:
+      ddl-auto: create
+    generate-ddl: true
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    defer-datasource-initialization: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+
+security:
+  jwt:
+    secret_key: ${random.value}"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 spring:
+  config.import: optional:classpath:property-override.yml
   profiles:
     active: local  # Default Active Profile
     group:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    active: local  # Default Active Profile
+    group:
+      local: local  # Add 'local-remoteDB' to connect Remote MySQL
+      dev: dev
+
+springdoc:
+  api-docs:
+    path: /api/v3/api-docs
+  swagger-ui:
+    path: /api/docs
+    tags-sorter: alpha
+    operations-sorter: alpha
+
+server:
+  port: 8080

--- a/backend/src/main/resources/datasource.yml
+++ b/backend/src/main/resources/datasource.yml
@@ -1,0 +1,17 @@
+# Default In-Memory H2
+spring:
+  datasource:
+    hikari:
+      jdbc-url: jdbc:h2:mem:momo;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE  # MySQL 호환 모드
+      username: sa
+
+--- # MySQL Remote Test Server
+spring:
+  config:
+    activate.on-profile: local-remoteDB
+    import: classpath:security/datasource-dev.yml
+  jpa:
+    hibernate:
+      ddl-auto: update
+    generate-ddl: false
+    defer-datasource-initialization: false

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -7,10 +7,18 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+        use_sql_comments: true
   sql:
     init:
       mode: never
 
+logging:
+  level:
+    org.hibernate.orm.jdbc:
+      type: trace
+      bind: trace
+      extract: trace
+
 security:
   jwt:
-    secret_key: 7JWI64WV7Jqw66as64qU66qo66qo64uk64uk7Jio7J6s7KaI67Cw7YKk7Y6Y65Oc66Gc66eI7YGs67mZ67SJ64KZ7YOA7ZW066as66CI7Lig6rOg7Jqw66as7J2Y66qp7KCB7J2A7IS46rOE7KCV67O17J2064ukYnRz7IaQ7Z2l66+867SJ7KSA7Zi4bW9tb+ugiOy4oOqzoA
+    secret_key: ${random.value}"


### PR DESCRIPTION
## 관련 이슈

- resolves: #134 

## 작업 내용

### MySQL 서버 연결
현재 배포된 서버는 개발용 서버의 느낌이 강하므로 AWS상에서 DB용 인스턴스를 추가하고 서브넷을 구성하는 대신, 제 개인 서버에 구축해 둔 MySQL 서버에 연결해 두었습니다.
(외부 접속이 비허용된 AWS의 인바운드 정책을 저희가 수정할 수 없으므로, 개발용 DB 서버를 AWS상에서 구축할 경우 불편할 것으로 판단했어요🙂)

이후 전체적인 기능이 완성되고 스키마가 확정됐을 때 AWS상에서 Private Subnet을 만들어 DB 서버를 해당 서브넷 안에 구축하면 될 것 같습니다.

### `application.yml` 프로필 분리 (`local`, `dev`)
환경을 쉽게 관리하기 위해 프로필을 분리했습니다.

| 프로파일 | DB | JWT Secret | `hibernate.ddl-auto` |
|--------|--------|--------|--------|
| `local` | In-Memory H2 | 랜덤 값 | create |
| `dev` | MySQL 테스트 서버 | 개발서버용 시크릿 | update |
| `local` + `local-remoteDB` | MySQL 테스트 서버 | 랜덤 값 | update | 

```yml
# /src/main/resource/application.yml

spring:
  config.import: optional:classpath:property-override.yml  # (*1)
  profiles:
    active: local  # (*2)
    group:
      local: local  # (*3)
      dev: dev
```
- *1) 로컬 개발 환경에서 프로퍼티를 쉽게 오버라이드하기 위한 옵션입니다.
  - `/src/main/resource/property-override.yml` 을 생성하고 오버라이드할 프로퍼티를 정의하면 해당 값이 우선적으로 사용됩니다.
  - ```yml
    # /src/main/resource/property-override.yml
    
    server.port: 9999  # 이와 같이 정의하면 9999포트를 사용하는 것으로 설정이 오버라이드됩니다.
    ```
- *2) 프로필 인자 없이 실행됐을 때 활성화될 기본 프로필입니다. (기본값: `local`)
- *3) `local` 그룹에 `local-remoteDB`를 추가하여 두 개의 프로필을 함께 활성화하면 로컬 개발환경에서도 MySQL 테스트 서버에 연결할 수 있습니다.

### 분리된 프로필을 반영하기 위한 CD 스크립트, Dockerfile 수정
- 컨테이너를 실행할 때 `dev` 프로필을 설정하여 실행합니다.
- 컨테이너 내부 파일들은 이제 `/momo` 내부에서 관리됩니다.
  - 이에 따라 도커 볼륨 역시 `/security`에서 `/momo/security`로 변경되었습니다.

### 테스트 프로퍼티
- 테스트 시 사용할 JWT 시크릿 값을 랜덤한 값을 불러오도록 변경했습니다. 
- Hibernate가 생성해 주는 쿼리에서 `?`에 바인딩되는 값을 볼 수 있도록 로그를 추가했습니다.
```log
Hibernate: 
    /* insert for
        kr.momo.domain.meeting.Meeting */insert 
    into
        meeting (created_at, is_locked, modified_at, name, end_timeslot, start_timeslot, uuid, id) 
    values
        (?, ?, ?, ?, ?, ?, ?, default)
org.hibernate.orm.jdbc.bind              : binding parameter (1:TIMESTAMP) <- [2024-08-01T14:17:39.563895]
org.hibernate.orm.jdbc.bind              : binding parameter (2:BOOLEAN) <- [false]
org.hibernate.orm.jdbc.bind              : binding parameter (3:TIMESTAMP) <- [2024-08-01T14:17:39.563895]
org.hibernate.orm.jdbc.bind              : binding parameter (4:VARCHAR) <- [저녁식사]
org.hibernate.orm.jdbc.bind              : binding parameter (5:ENUM) <- [TIME_2130]
org.hibernate.orm.jdbc.bind              : binding parameter (6:ENUM) <- [TIME_1800]
org.hibernate.orm.jdbc.bind              : binding parameter (7:VARCHAR) <- [dinner]
org.hibernate.orm.jdbc.extract           : extracted value (1:BIGINT) -> [1]
```

### yml 로드 구조
- `../r`: `/src/main/resources`
- `../r/s`: `/src/main/resources/security` (submodule)

| 번호 | 경로 | 역할 | 타 프로퍼티 import |
|-----|--------|--------|--------|
| 1 | `../r/application.yml` | 프로젝트 공통 프로퍼티 설정 | 7. `r/property-override.yml` |
| 2 | `../r/application-local.yml` | `local` 프로필 전용 프로퍼티 설정 | 4. `r/datasource.yml` |
| 3 | `../r/application-dev.yml` | `dev` 프로필 전용 프로퍼티 설정 | 5. `r/s/datasource-dev.yml`<br>6. `r/s/jwt.yml` |
| 4 | `../r/datasource.yml` | 로컬 개발환경 DB 설정 | 5. `r/s/datasource-dev.yml` |
| 5 | `../r/s/datasource-dev.yml` | dev 배포 환경 DB 설정 | - | 
| 6 | `../r/s/jwt.yml` | dev 배포 환경 JWT 시크릿 설정 | - | 
| 7 | `../r/property-override.yml` | 임시 프로퍼티 오버라이드 | - | 


## 특이 사항

- 서브모듈이 업데이트되었습니다.
- 더 이상 `classpath:application.yml`은 `.gitignore` 처리되지 않습니다.
  - **⚠️ 해당 파일에 중요 정보를 포함하여 커밋하지 마세요 ⚠️**
  - 중요 정보들은 서브모듈에서 관리하고, `application.yml`에서는 서브모듈의 `yml`을 임포트하여 사용합니다.
- `bootJar` 생성 시 모든 `yml` 파일들을 제외하는 설정을 제거하고 `/security/**` 파일들만 제외하도록 변경하였습니다.
- 서브모듈에서 `yml` 파일을 복사하는 테스크는 더 이상 필요하지 않으므로 해당 gradle task를 제거했습니다.


## 리뷰 요구사항 (선택)

`yml` 파일 구조를 한번씩 숙지하시고 가시면 좋을 것 같아요~
궁금한 점 있으시면 코멘트 주세요😀