### PR TITLE
[BE] 약속 생성시 과거 날짜 검증 추가

### DIFF
--- a/backend/src/main/java/kr/momo/config/TimeConfig.java
+++ b/backend/src/main/java/kr/momo/config/TimeConfig.java
@@ -1,0 +1,17 @@
+package kr.momo.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    private static final ZoneId CLOCK_TIME_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(CLOCK_TIME_ZONE);
+    }
+}

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -2,6 +2,7 @@ package kr.momo.controller.meeting;
 
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.LocalDate;
 import kr.momo.controller.CookieManager;
 import kr.momo.controller.MomoApiResponse;
 import kr.momo.controller.auth.AuthAttendee;
@@ -31,7 +32,8 @@ public class MeetingController {
     public ResponseEntity<MomoApiResponse<MeetingCreateResponse>> create(
             @RequestBody @Valid MeetingCreateRequest request
     ) {
-        MeetingCreateResponse response = meetingService.create(request);
+        LocalDate today = LocalDate.now();
+        MeetingCreateResponse response = meetingService.create(request, today);
         String path = String.format("/meeting/%s", response.uuid());
         String cookie = cookieManager.createNewCookie(response.token(), path);
 

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -2,7 +2,6 @@ package kr.momo.controller.meeting;
 
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.time.LocalDate;
 import kr.momo.controller.CookieManager;
 import kr.momo.controller.MomoApiResponse;
 import kr.momo.controller.auth.AuthAttendee;
@@ -32,8 +31,7 @@ public class MeetingController {
     public ResponseEntity<MomoApiResponse<MeetingCreateResponse>> create(
             @RequestBody @Valid MeetingCreateRequest request
     ) {
-        LocalDate today = LocalDate.now();
-        MeetingCreateResponse response = meetingService.create(request, today);
+        MeetingCreateResponse response = meetingService.create(request);
         String path = String.format("/meeting/%s", response.uuid());
         String cookie = cookieManager.createNewCookie(response.token(), path);
 

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDate.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDate.java
@@ -40,7 +40,11 @@ public class AvailableDate extends BaseEntity {
         this.meeting = meeting;
     }
 
+    public boolean isBefore(LocalDate other) {
+        return date.isBefore(other);
+    }
+
     public boolean isSameDate(LocalDate other) {
-        return this.date.equals(other);
+        return date.equals(other);
     }
 }

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
@@ -15,7 +15,7 @@ public class AvailableDates {
     private final List<AvailableDate> availableDates;
 
     public AvailableDates(List<LocalDate> dates, Meeting meeting) {
-        validateDuplicatedDates(dates);
+        validateUniqueDates(dates);
         this.availableDates = dates.stream()
                 .map(date -> new AvailableDate(date, meeting))
                 .toList();
@@ -25,11 +25,16 @@ public class AvailableDates {
         this.availableDates = availableDates;
     }
 
-    private void validateDuplicatedDates(List<LocalDate> dates) {
+    private void validateUniqueDates(List<LocalDate> dates) {
         Set<LocalDate> dateSet = new HashSet<>(dates);
         if (dateSet.size() != dates.size()) {
             throw new MomoException(AvailableDateErrorCode.DUPLICATED_DATE);
         }
+    }
+
+    public boolean isAllBefore(LocalDate other) {
+        return availableDates.stream()
+                .anyMatch(date -> date.isBefore(other));
     }
 
     public AvailableDate findByDate(LocalDate other) {

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
@@ -32,7 +32,7 @@ public class AvailableDates {
         }
     }
 
-    public boolean isAllBefore(LocalDate other) {
+    public boolean isAnyBefore(LocalDate other) {
         return availableDates.stream()
                 .anyMatch(date -> date.isBefore(other));
     }

--- a/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
@@ -7,7 +7,8 @@ public enum MeetingErrorCode implements ErrorCodeType {
     INVALID_UUID(HttpStatus.BAD_REQUEST, "유효하지 않은 UUID 입니다."),
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, "존재하지 않는 약속 정보 입니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "끝 시간은 시작 시간 이후가 되어야 합니다."),
-    MEETING_LOCKED(HttpStatus.BAD_REQUEST, "약속이 잠겨있어 수행할 수 없습니다.");
+    MEETING_LOCKED(HttpStatus.BAD_REQUEST, "약속이 잠겨있어 수행할 수 없습니다."),
+    NOT_AVAILABLE_MEETING(HttpStatus.BAD_REQUEST, "약속 생성이 불가능한 날짜입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
@@ -8,7 +8,7 @@ public enum MeetingErrorCode implements ErrorCodeType {
     NOT_FOUND_MEETING(HttpStatus.NOT_FOUND, "존재하지 않는 약속 정보 입니다."),
     INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "끝 시간은 시작 시간 이후가 되어야 합니다."),
     MEETING_LOCKED(HttpStatus.BAD_REQUEST, "약속이 잠겨있어 수행할 수 없습니다."),
-    NOT_AVAILABLE_MEETING(HttpStatus.BAD_REQUEST, "약속 생성이 불가능한 날짜입니다.");
+    PAST_NOT_PERMITTED(HttpStatus.BAD_REQUEST, "과거 날짜로는 약속을 생성할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -54,7 +54,7 @@ public class MeetingService {
     private void saveAvailableDates(List<LocalDate> dates, Meeting meeting, LocalDate date) {
         AvailableDates availableDates = new AvailableDates(dates, meeting);
         if (availableDates.isAnyBefore(date)) {
-            throw new MomoException(MeetingErrorCode.NOT_AVAILABLE_MEETING);
+            throw new MomoException(MeetingErrorCode.PAST_NOT_PERMITTED);
         }
         availableDateRepository.saveAll(availableDates.getAvailableDates());
     }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -1,5 +1,6 @@
 package kr.momo.service.meeting;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -27,13 +28,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MeetingService {
 
+    private final JwtManager jwtManager;
+    private final Clock clock;
     private final MeetingRepository meetingRepository;
     private final AvailableDateRepository availableDateRepository;
     private final AttendeeRepository attendeeRepository;
-    private final JwtManager jwtManager;
 
     @Transactional
-    public MeetingCreateResponse create(MeetingCreateRequest request, LocalDate today) {
+    public MeetingCreateResponse create(MeetingCreateRequest request) {
+        LocalDate today = LocalDate.now(clock);
         Meeting meeting = saveMeeting(request.meetingName(), request.meetingStartTime(), request.meetingEndTime());
         saveAvailableDates(request.meetingAvailableDates(), meeting, today);
 
@@ -66,7 +69,8 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
         AvailableDates availableDates = new AvailableDates(
-                availableDateRepository.findAllByMeetingOrderByDate(meeting));
+                availableDateRepository.findAllByMeetingOrderByDate(meeting)
+        );
         List<Attendee> attendees = attendeeRepository.findAllByMeeting(meeting);
 
         return MeetingResponse.of(meeting, availableDates, attendees);

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -50,7 +50,7 @@ public class MeetingService {
 
     private void saveAvailableDates(List<LocalDate> dates, Meeting meeting, LocalDate date) {
         AvailableDates availableDates = new AvailableDates(dates, meeting);
-        if (availableDates.isAllBefore(date)) {
+        if (availableDates.isAnyBefore(date)) {
             throw new MomoException(MeetingErrorCode.NOT_AVAILABLE_MEETING);
         }
         availableDateRepository.saveAll(availableDates.getAvailableDates());

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -106,11 +106,14 @@ class MeetingControllerTest {
     @DisplayName("약속을 생성하면 201 상태코드를 반환한다.")
     @Test
     void create() {
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
+        LocalDate dayAfterTomorrow = today.plusDays(2);
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                List.of(LocalDate.of(2024, 7, 24), LocalDate.of(2024, 7, 25)),
+                List.of(tomorrow, dayAfterTomorrow),
                 LocalTime.of(8, 0),
                 LocalTime.of(22, 0));
 
@@ -127,14 +130,16 @@ class MeetingControllerTest {
     @DisplayName("약속을 생성할 때 중복되는 날짜로 요청하면 400을 반환한다.")
     @Test
     void createByDuplicatedName() {
-        LocalDate date = LocalDate.of(2024, 7, 24);
+        LocalDate today = LocalDate.now();
+        LocalDate tomorrow = today.plusDays(1);
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                List.of(date, date),
+                List.of(tomorrow, tomorrow),
                 LocalTime.of(8, 0),
-                LocalTime.of(22, 0));
+                LocalTime.of(22, 0)
+        );
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDateTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDateTest.java
@@ -1,0 +1,27 @@
+package kr.momo.domain.availabledate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import kr.momo.domain.meeting.Meeting;
+import kr.momo.fixture.MeetingFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AvailableDateTest {
+
+    @DisplayName("이용 가능한 날짜가 과거인지 검증한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"-2,true", "-1,true", "0,false", "1,false"})
+    void isBefore(int plusDays, boolean expected) {
+        Meeting meeting = MeetingFixture.GAME.create();
+        LocalDate today = LocalDate.now();
+        LocalDate given = today.plusDays(plusDays);
+        AvailableDate availableDate = new AvailableDate(given, meeting);
+
+        boolean result = availableDate.isBefore(today);
+
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
@@ -82,7 +82,7 @@ class AvailableDatesTest {
     @DisplayName("가능한 시간 목록 중 하나라도 비교군보다 이전 시간인지 판단한다.")
     @ParameterizedTest
     @CsvSource(value = {"-3,-2,-1,true", "-2,-1,0,true", "-1,0,1,true", "0,1,2,false", "1,2,3,false"})
-    void isAllBefore(int plusDays1, int plusDays2, int plusDays3, boolean expected) {
+    void isAnyBefore(int plusDays1, int plusDays2, int plusDays3, boolean expected) {
         LocalDate today = LocalDate.now();
         LocalDate firstDay = today.plusDays(plusDays1);
         LocalDate secondDay = today.plusDays(plusDays2);
@@ -94,7 +94,7 @@ class AvailableDatesTest {
                 new AvailableDate(thirdDay, meeting)
         ));
 
-        boolean result = availableDates.isAllBefore(today);
+        boolean result = availableDates.isAnyBefore(today);
 
         assertThat(result).isEqualTo(expected);
     }

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
@@ -12,6 +12,8 @@ import kr.momo.exception.code.AvailableDateErrorCode;
 import kr.momo.fixture.MeetingFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class AvailableDatesTest {
 
@@ -75,5 +77,25 @@ class AvailableDatesTest {
         // when then
         assertThatCode(() -> new AvailableDates(dates, meeting))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("가능한 시간 목록 중 하나라도 비교군보다 이전 시간인지 판단한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"-3,-2,-1,true", "-2,-1,0,true", "-1,0,1,true", "0,1,2,false", "1,2,3,false"})
+    void isAllBefore(int plusDays1, int plusDays2, int plusDays3, boolean expected) {
+        LocalDate today = LocalDate.now();
+        LocalDate firstDay = today.plusDays(plusDays1);
+        LocalDate secondDay = today.plusDays(plusDays2);
+        LocalDate thirdDay = today.plusDays(plusDays3);
+        Meeting meeting = MeetingFixture.GAME.create();
+        AvailableDates availableDates = new AvailableDates(List.of(
+                new AvailableDate(firstDay, meeting),
+                new AvailableDate(secondDay, meeting),
+                new AvailableDate(thirdDay, meeting)
+        ));
+
+        boolean result = availableDates.isAllBefore(today);
+
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -3,9 +3,13 @@ package kr.momo.service.meeting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doReturn;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.attendee.AttendeeRepository;
@@ -28,10 +32,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 @IsolateDatabase
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class MeetingServiceTest {
+
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2024-08-01T10:15:30Z"), ZoneId.of("Asia/Seoul"));
+
+    @SpyBean
+    private Clock clock;
 
     @Autowired
     private MeetingService meetingService;
@@ -93,18 +104,19 @@ class MeetingServiceTest {
     @Test
     void throwExceptionWhenDuplicatedDates() {
         //given
-        LocalDate today = LocalDate.of(2024, 7, 23);
-        LocalDate date = LocalDate.of(2024, 7, 24);
+        setFixedClock();
+        LocalDate today = LocalDate.now(clock);
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "momoHost",
                 "momo",
                 "momoMeeting",
-                List.of(date, date),
+                List.of(today, today),
                 LocalTime.of(8, 0),
-                LocalTime.of(22, 0));
+                LocalTime.of(22, 0)
+        );
 
         //when //then
-        assertThatThrownBy(() -> meetingService.create(request, today))
+        assertThatThrownBy(() -> meetingService.create(request))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
     }
@@ -113,7 +125,8 @@ class MeetingServiceTest {
     @Test
     void throwExceptionWhenDatesHavePast() {
         //given
-        LocalDate today = LocalDate.of(2024, 7, 23);
+        setFixedClock();
+        LocalDate today = LocalDate.now(clock);
         LocalDate yesterday = today.minusDays(1);
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "momoHost",
@@ -121,10 +134,11 @@ class MeetingServiceTest {
                 "momoMeeting",
                 List.of(yesterday, today),
                 LocalTime.of(8, 0),
-                LocalTime.of(22, 0));
+                LocalTime.of(22, 0)
+        );
 
         //when //then
-        assertThatThrownBy(() -> meetingService.create(request, today))
+        assertThatThrownBy(() -> meetingService.create(request))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(MeetingErrorCode.NOT_AVAILABLE_MEETING.message());
     }
@@ -227,5 +241,11 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.unlock(uuid, id))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AttendeeErrorCode.ACCESS_DENIED.message());
+    }
+
+    private void setFixedClock() {
+        doReturn(Instant.now(FIXED_CLOCK))
+                .when(clock)
+                .instant();
     }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -38,8 +38,9 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class MeetingServiceTest {
 
-    private static final Clock FIXED_CLOCK =
-            Clock.fixed(Instant.parse("2024-08-01T10:15:30Z"), ZoneId.of("Asia/Seoul"));
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2024-08-01T10:15:30Z"), ZoneId.of("Asia/Seoul")
+    );
 
     @SpyBean
     private Clock clock;

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -140,7 +140,7 @@ class MeetingServiceTest {
         //when //then
         assertThatThrownBy(() -> meetingService.create(request))
                 .isInstanceOf(MomoException.class)
-                .hasMessage(MeetingErrorCode.NOT_AVAILABLE_MEETING.message());
+                .hasMessage(MeetingErrorCode.PAST_NOT_PERMITTED.message());
     }
 
     @DisplayName("약속을 잠그면 잠금 상태가 변경된다.")

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -93,6 +93,7 @@ class MeetingServiceTest {
     @Test
     void throwExceptionWhenDuplicatedDates() {
         //given
+        LocalDate today = LocalDate.of(2024, 7, 23);
         LocalDate date = LocalDate.of(2024, 7, 24);
         MeetingCreateRequest request = new MeetingCreateRequest(
                 "momoHost",
@@ -103,9 +104,29 @@ class MeetingServiceTest {
                 LocalTime.of(22, 0));
 
         //when //then
-        assertThatThrownBy(() -> meetingService.create(request))
+        assertThatThrownBy(() -> meetingService.create(request, today))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
+    }
+
+    @DisplayName("약속을 생성할 때 과거 날짜를 보내면 예외가 발생합니다.")
+    @Test
+    void throwExceptionWhenDatesHavePast() {
+        //given
+        LocalDate today = LocalDate.of(2024, 7, 23);
+        LocalDate yesterday = today.minusDays(1);
+        MeetingCreateRequest request = new MeetingCreateRequest(
+                "momoHost",
+                "momo",
+                "momoMeeting",
+                List.of(yesterday, today),
+                LocalTime.of(8, 0),
+                LocalTime.of(22, 0));
+
+        //when //then
+        assertThatThrownBy(() -> meetingService.create(request, today))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.NOT_AVAILABLE_MEETING.message());
     }
 
     @DisplayName("약속을 잠그면 잠금 상태가 변경된다.")


### PR DESCRIPTION
## 관련 이슈

- resolves: #135 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- 약속 생성시 과거 날짜가 포함되어 있다면 예외가 발생하도록 검증을 추가하였습니다.
- 관련한 테스트도 추가하였어요.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

>  추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요?

현재 날짜(`LocalDate`) 객체 생성이 적절한 계층에 수행되고 있는지 궁금합니다. 과거 시간 검증은 API가 요청된 시점의 오늘을 기준으로 이전 날짜인지 검증하게 되는데요.  이때 비즈니스 로직에 대한 테스트를 위해 Persistence Layer(`MeetingController`)에 위치하고 있습니다. 이것이 적절한지 궁금합니다.

> 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요?

과거 시간 검증에 대한 인수 테스트(`ControllerTest`)가 필요한지 궁금합니다. 현재 테스트 내 400 Bad Request 상황에 올바른 상태코드를 반환하는 테스트가 이미 있는데요. 과거 검증 인수테스트를 추가한다면 문맥은 다르나 테스트하고자 하는 목적이 `400 Bad Request` 반환으로 동일할 것 같다 생각하기 때문입니다. 여러분의 의견이 궁금하네요. 필요하다면 바로 반영하겠습니다.

