### PR TITLE
[BE] 미팅 조회 시 날짜 정보를 정렬하여 반환하도록 수정

### DIFF
--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDateRepository.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDateRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
 
     List<AvailableDate> findAllByMeeting(Meeting meeting);
+
+    List<AvailableDate> findAllByMeetingOrderByDate(Meeting meeting);
 }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -56,7 +56,7 @@ public class MeetingService {
     public MeetingResponse findByUUID(String uuid) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
-        AvailableDates availableDates = new AvailableDates(availableDateRepository.findAllByMeeting(meeting));
+        AvailableDates availableDates = new AvailableDates(availableDateRepository.findAllByMeetingOrderByDate(meeting));
         List<Attendee> attendees = attendeeRepository.findAllByMeeting(meeting);
 
         return MeetingResponse.of(meeting, availableDates, attendees);


### PR DESCRIPTION
## 관련 이슈

- resolves: #148 

## 작업 내용

<img width="586" alt="image" src="https://github.com/user-attachments/assets/bfd5d519-4da8-4c28-b3a1-ff64785db9ea">

미팅 정보 응답 시 날짜를 정렬해서 응답합니다.

## 특이 사항

없음
