### PR TITLE
[BE] JWT 쿠키의 경로와 도메인 값 지정

### DIFF
--- a/backend/src/main/java/kr/momo/controller/CookieManager.java
+++ b/backend/src/main/java/kr/momo/controller/CookieManager.java
@@ -29,4 +29,8 @@ public class CookieManager {
                 .build()
                 .toString();
     }
+
+    public String pathOf(String meetingUuid) {
+        return String.format("/api/v1/meeting/%s/", meetingUuid);
+    }
 }

--- a/backend/src/main/java/kr/momo/controller/CookieManager.java
+++ b/backend/src/main/java/kr/momo/controller/CookieManager.java
@@ -1,5 +1,6 @@
 package kr.momo.controller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,12 @@ public class CookieManager {
     private static final String SAME_SITE_OPTION = "None";
     private static final long SESSION_COOKIE_AGE = -1;
     private static final long EXPIRED_COOKIE_AGE = 0;
+
+    private final String cookieDomain;
+
+    public CookieManager(@Value("${security.cookie.domain}") String cookieDomain) {
+        this.cookieDomain = cookieDomain;
+    }
 
     public String createNewCookie(String value, String path) {
         return createCookie(value, path, SESSION_COOKIE_AGE);
@@ -23,6 +30,7 @@ public class CookieManager {
         return ResponseCookie.from(ACCESS_TOKEN, value)
                 .httpOnly(true)
                 .secure(true)
+                .domain(cookieDomain)
                 .path(path)
                 .sameSite(SAME_SITE_OPTION)
                 .maxAge(maxAge)

--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
@@ -26,7 +26,7 @@ public class AttendeeController {
             @PathVariable String uuid, @RequestBody @Valid AttendeeLoginRequest request
     ) {
         AttendeeLoginResponse response = attendeeService.login(uuid, request);
-        String path = String.format("/meeting/%s", uuid);
+        String path = cookieManager.pathOf(uuid);
         String cookie = cookieManager.createNewCookie(response.token(), path);
 
         return ResponseEntity.ok()

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -32,7 +32,7 @@ public class MeetingController {
             @RequestBody @Valid MeetingCreateRequest request
     ) {
         MeetingCreateResponse response = meetingService.create(request);
-        String path = String.format("/meeting/%s", response.uuid());
+        String path = cookieManager.pathOf(response.uuid());
         String cookie = cookieManager.createNewCookie(response.token(), path);
 
         return ResponseEntity.created(URI.create("/meeting/" + response.uuid()))

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -25,4 +25,6 @@ security:
     secret-key: ${random.value}"
     expiration-period: 1h
   allow-origins:
-    - http://localhost:[*]
+      - http://localhost:[*]
+  cookie:
+    domain: "localhost"

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -25,3 +25,5 @@ security:
     expiration-period: 1h
   allow-origins:
     - http://localhost:[*]
+  cookie:
+    domain: "localhost"


### PR DESCRIPTION
## 관련 이슈

- resolves: #162 

## 작업 내용

JWT 저장용 쿠키 응답 시 도메인을 설정하고, 올바를 Path 정보를 응답하도록 수정했습니다.

## 특이 사항

서브모듈이 업데이트되었습니다.
`CorsConfig`의 `.allowedOriginPatterns()` 이 제대로 동작하지 않는 오류가 있습니다.
`String[]` 을 문자열로 만들지 않고 그대로 전달하는 것으로 변경해야 정상 동작합니다.

이후 다른 이슈를 만들어 수정하겠습니다!

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
