### PR TITLE
[BE] 스케줄 생성 시 참여자의 이름을 전달받지 않도록 변경

### DIFF
--- a/backend/src/main/java/kr/momo/service/schedule/dto/ScheduleCreateRequest.java
+++ b/backend/src/main/java/kr/momo/service/schedule/dto/ScheduleCreateRequest.java
@@ -1,8 +1,7 @@
 package kr.momo.service.schedule.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record ScheduleCreateRequest(@NotBlank String attendeeName, @NotNull List<DateTimesCreateRequest> dateTimes) {
+public record ScheduleCreateRequest(@NotNull List<DateTimesCreateRequest> dateTimes) {
 }

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -82,7 +82,7 @@ class ScheduleControllerTest {
                 new DateTimesCreateRequest(tomorrow.getDate(), times)
         );
 
-        ScheduleCreateRequest scheduleCreateRequest = new ScheduleCreateRequest(attendee.name(), dateTimes);
+        ScheduleCreateRequest scheduleCreateRequest = new ScheduleCreateRequest(dateTimes);
 
         RestAssured.given().log().all()
                 .cookie("ACCESS_TOKEN", token)

--- a/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
@@ -79,7 +79,7 @@ class ScheduleServiceTest {
     @DisplayName("스케줄 생성 시 사용자의 기존 스케줄들을 모두 삭제하고 새로운 스케줄을 저장한다.")
     @Test
     void createSchedulesReplacesOldSchedules() {
-        ScheduleCreateRequest request = new ScheduleCreateRequest(attendee.name(), dateTimes);
+        ScheduleCreateRequest request = new ScheduleCreateRequest(dateTimes);
         scheduleRepository.saveAll(List.of(
                 new Schedule(attendee, today, Timeslot.TIME_0130),
                 new Schedule(attendee, tomorrow, Timeslot.TIME_0130)
@@ -97,24 +97,11 @@ class ScheduleServiceTest {
         Meeting other = MeetingFixture.DINNER.create();
         String invalidUUID = other.getUuid();
         long attendeeId = attendee.getId();
-        ScheduleCreateRequest request = new ScheduleCreateRequest(attendee.name(), dateTimes);
+        ScheduleCreateRequest request = new ScheduleCreateRequest(dateTimes);
 
         assertThatThrownBy(() -> scheduleService.create(invalidUUID, attendeeId, request))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(MeetingErrorCode.INVALID_UUID.message());
-    }
-
-    @DisplayName("약속에 참가자 정보가 존재하지 않으면 예외를 발생시킨다.")
-    @Test
-    void throwsExceptionWhenInvalidAttendee() {
-        long invalidAttendeeId = 2L;
-        String invalidAttendeeName = "invalidAttendeeName";
-        String uuid = meeting.getUuid();
-        ScheduleCreateRequest request = new ScheduleCreateRequest(invalidAttendeeName, dateTimes);
-
-        assertThatThrownBy(() -> scheduleService.create(uuid, invalidAttendeeId, request))
-                .isInstanceOf(MomoException.class)
-                .hasMessage(AttendeeErrorCode.INVALID_ATTENDEE.message());
     }
 
     @DisplayName("스케줄 생성시 약속이 잠겨있다면 예외를 발생시킨다.")
@@ -123,7 +110,7 @@ class ScheduleServiceTest {
         Meeting game = MeetingFixture.GAME.create();
         game.lock();
         Meeting lockedMeeting = meetingRepository.save(game);
-        ScheduleCreateRequest request = new ScheduleCreateRequest(attendee.name(), dateTimes);
+        ScheduleCreateRequest request = new ScheduleCreateRequest(dateTimes);
         String givenUUID = lockedMeeting.getUuid();
         Long givenAttendeeId = attendee.getId();
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #166 

## 작업 내용

스케줄 생성 시 참여자의 이름 정보를 전달받지 않도록 변경하였습니다.

## 특이 사항

기존의 `ScheduleCreateRequest`는 attendeeName 필드가 존재하여 참여자의 이름을 전달받고 있었지만, 해당 필드는 사용되지 않았습니다.

제거 후 사용자 이름이 필요한 문맥에서는 JWT에서 파싱한 참여자 ID를 기반으로 DB를 조회하여 가져올 수 있습니다.

cc. @Yoonkyoungme 