### PR TITLE
[BE] 약속 확정 취소 기능 구현

### DIFF
--- a/backend/src/main/java/kr/momo/controller/annotation/ApiSuccessResponse.java
+++ b/backend/src/main/java/kr/momo/controller/annotation/ApiSuccessResponse.java
@@ -28,4 +28,13 @@ public @interface ApiSuccessResponse {
         @AliasFor(annotation = ApiResponse.class, attribute = "description")
         String value() default "";
     }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Operation
+    @ApiResponse(responseCode = "204", description = "No Content")
+    @interface NoContent {
+        @AliasFor(annotation = ApiResponse.class, attribute = "description")
+        String value() default "";
+    }
 }

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -16,6 +16,7 @@ import kr.momo.service.meeting.dto.MeetingConfirmRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,5 +74,11 @@ public class MeetingController implements MeetingControllerDocs {
     @PatchMapping("/api/v1/meetings/{uuid}/unlock")
     public void unlock(@PathVariable String uuid, @AuthAttendee long id) {
         meetingService.unlock(uuid, id);
+    }
+
+    @DeleteMapping("/api/v1/meetings/{uuid}/confirmed")
+    public ResponseEntity<Void> cancelConfirmedMeeting(@PathVariable String uuid, @AuthAttendee long id) {
+        meetingConfirmService.delete(uuid, id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -7,12 +7,12 @@ import kr.momo.controller.MomoApiResponse;
 import kr.momo.controller.auth.AuthAttendee;
 import kr.momo.service.meeting.MeetingConfirmService;
 import kr.momo.service.meeting.MeetingService;
+import kr.momo.service.meeting.dto.MeetingConfirmRequest;
 import kr.momo.service.meeting.dto.MeetingConfirmResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingCreateResponse;
 import kr.momo.service.meeting.dto.MeetingResponse;
 import kr.momo.service.meeting.dto.MeetingSharingResponse;
-import kr.momo.service.meeting.dto.MeetingConfirmRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -50,7 +50,7 @@ public class MeetingController implements MeetingControllerDocs {
             @PathVariable String uuid, @AuthAttendee long id, @RequestBody @Valid MeetingConfirmRequest request
     ) {
         MeetingConfirmResponse response = meetingConfirmService.create(uuid, id, request);
-        return ResponseEntity.created(URI.create("/api/v1/meetings/" + uuid + "/confirmed"))
+        return ResponseEntity.created(URI.create("/api/v1/meetings/" + uuid + "/confirm"))
                 .body(new MomoApiResponse<>(response));
     }
 
@@ -76,7 +76,7 @@ public class MeetingController implements MeetingControllerDocs {
         meetingService.unlock(uuid, id);
     }
 
-    @DeleteMapping("/api/v1/meetings/{uuid}/confirmed")
+    @DeleteMapping("/api/v1/meetings/{uuid}/confirm")
     public ResponseEntity<Void> cancelConfirmedMeeting(@PathVariable String uuid, @AuthAttendee long id) {
         meetingConfirmService.delete(uuid, id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingControllerDocs.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingControllerDocs.java
@@ -99,4 +99,18 @@ public interface MeetingControllerDocs {
             @PathVariable @Schema(description = "약속 UUID") String uuid,
             @AuthAttendee @Schema(hidden = true) long id
     );
+
+    @ApiSuccessResponse.NoContent("약속 취소 성공")
+    @ApiErrorResponse.BadRequest("""
+            요청이 잘못되었습니다.
+            1. 유효하지 않은 UUID
+            2. 유효하지 않은 주최자 정보
+            """
+    )
+    @ApiErrorResponse.Unauthorized("JWT 토큰 인증에 실패하였습니다.")
+    @ApiErrorResponse.Forbidden("주최자 권한만 가능합니다.")
+    public ResponseEntity<Void> cancelConfirmedMeeting(
+            @PathVariable @Schema(description = "약속 UUID") String uuid,
+            @AuthAttendee @Schema(hidden = true) long id
+    );
 }

--- a/backend/src/main/java/kr/momo/domain/meeting/ConfirmedMeetingRepository.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/ConfirmedMeetingRepository.java
@@ -8,4 +8,6 @@ public interface ConfirmedMeetingRepository extends JpaRepository<ConfirmedMeeti
     Optional<ConfirmedMeeting> findByMeeting(Meeting meeting);
 
     boolean existsByMeeting(Meeting meeting);
+
+    void deleteByMeeting(Meeting meeting);
 }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingConfirmService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingConfirmService.java
@@ -94,4 +94,18 @@ public class MeetingConfirmService {
             throw new MomoException(MeetingErrorCode.INVALID_DATETIME_RANGE);
         }
     }
+
+    @Transactional
+    public void delete(String uuid, long attendeeId) {
+        Meeting meeting = meetingRepository.findByUuid(uuid)
+                .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
+
+        Attendee attendee = attendeeRepository.findByIdAndMeeting(attendeeId, meeting)
+                .orElseThrow(() -> new MomoException(AttendeeErrorCode.INVALID_ATTENDEE));
+        validateHostPermission(attendee);
+
+        confirmedMeetingRepository.deleteByMeeting(meeting);
+
+        meeting.unlock();
+    }
 }

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -289,7 +289,7 @@ class MeetingControllerTest {
                 .when().post("/api/v1/meetings/{uuid}/confirm")
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value())
-                .header("Location", "/api/v1/meetings/" + meeting.getUuid() + "/confirmed");
+                .header("Location", "/api/v1/meetings/" + meeting.getUuid() + "/confirm");
     }
 
     private Meeting createLockedMovieMeeting() {
@@ -354,7 +354,7 @@ class MeetingControllerTest {
                 .cookie("ACCESS_TOKEN", token)
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
-                .when().delete("/api/v1/meetings/{uuid}/confirmed")
+                .when().delete("/api/v1/meetings/{uuid}/confirm")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
 
@@ -375,7 +375,7 @@ class MeetingControllerTest {
                 .cookie("ACCESS_TOKEN", token)
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
-                .when().delete("/api/v1/meetings/{uuid}/confirmed")
+                .when().delete("/api/v1/meetings/{uuid}/confirm")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
@@ -392,7 +392,7 @@ class MeetingControllerTest {
                 .cookie("ACCESS_TOKEN", token)
                 .pathParam("uuid", meeting.getUuid())
                 .contentType(ContentType.JSON)
-                .when().delete("/api/v1/meetings/{uuid}/confirmed")
+                .when().delete("/api/v1/meetings/{uuid}/confirm")
                 .then().log().all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
     }

--- a/backend/src/test/java/kr/momo/fixture/ConfirmedMeetingFixture.java
+++ b/backend/src/test/java/kr/momo/fixture/ConfirmedMeetingFixture.java
@@ -1,0 +1,27 @@
+package kr.momo.fixture;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import kr.momo.domain.meeting.ConfirmedMeeting;
+import kr.momo.domain.meeting.Meeting;
+
+public enum ConfirmedMeetingFixture {
+
+    MOVIE(
+            LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(0, 0)),
+            LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.of(5, 30))
+    );
+
+    private final LocalDateTime startDateTime;
+    private final LocalDateTime endDateTime;
+
+    ConfirmedMeetingFixture(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+    }
+
+    public ConfirmedMeeting create(Meeting meeting) {
+        return new ConfirmedMeeting(meeting, startDateTime, endDateTime);
+    }
+}

--- a/backend/src/test/java/kr/momo/fixture/MeetingFixture.java
+++ b/backend/src/test/java/kr/momo/fixture/MeetingFixture.java
@@ -10,7 +10,7 @@ public enum MeetingFixture {
     DINNER("저녁식사", "dinner", LocalTime.of(18, 0), LocalTime.of(22, 0)),
     COFFEE("커피", "coffee", LocalTime.of(10, 0), LocalTime.of(14, 0)),
     GAME("게임", "game", LocalTime.of(18, 0), LocalTime.of(23, 30)),
-    DRINK("음주", "drink", LocalTime.of(0, 0), LocalTime.of(23, 59));
+    DRINK("음주", "drink", LocalTime.of(0, 0), LocalTime.of(0, 0));
 
     private final String name;
     private final String uuid;


### PR DESCRIPTION
## 관련 이슈

- resolves: #142 

## 작업 내용

주최자가 확정된 약속을 취소하는 기능을 구현했습니다. 

### API 명세

요청

```
DELETE /api/v1/meetings/{uuid}/confirmed HTTP/1.1
cookie: ~host-cookie~
```

응답

```
HTTP/1.1 204 No Content
```

## 특이 사항

- 확정된 약속을 취소하고 참가자들의 약속을 수정하는 경우가 많을 것이라 가정하여 **약속 잠금 해제까지 수행**합니다.
-  아직 확정 약속 조회 기능이 구현되지 않아 컨트롤러 테스트에서 repo를 통해 검증하는데 기능이 구현된다면 RestAssured로 검증할 예정입니다.

## 리뷰 요구사항 (선택)

- 약속 확정의 경우 `POST **/confirm` 취소와 조회의 경우 `GET or DELETE **/confirmed` 엔드포인트를 사용할 예정입니다. 헷갈릴 여지를 줄이기 위해 `/confirm` 경로를 사용하는 것이 나을지 의견이 궁금합니다.
- 확정된 약속이 존재하지 않더라고 삭제 요청 시 204 상태 코드를 응답합니다. 해당 상황으로 인해 클라이언트에서 문제로 인식하지 않아도 괜찮다고 생각했어요.