### PR TITLE
[BE] 미팅에 속하는 모든 참여자의 이름을 조회하는 API

### DIFF
--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
@@ -1,6 +1,7 @@
 package kr.momo.controller.attendee;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import kr.momo.controller.CookieManager;
 import kr.momo.controller.MomoApiResponse;
 import kr.momo.service.attendee.AttendeeService;
@@ -9,6 +10,7 @@ import kr.momo.service.attendee.dto.AttendeeLoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,5 +43,10 @@ public class AttendeeController implements AttendeeControllerDocs {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie)
                 .build();
+    }
+
+    @GetMapping("/api/v1/meetings/{uuid}/attendees")
+    public MomoApiResponse<List<String>> findInMeeting(@PathVariable String uuid) {
+        return new MomoApiResponse<>(attendeeService.findAll(uuid));
     }
 }

--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
@@ -46,7 +46,7 @@ public class AttendeeController implements AttendeeControllerDocs {
     }
 
     @GetMapping("/api/v1/meetings/{uuid}/attendees")
-    public MomoApiResponse<List<String>> findInMeeting(@PathVariable String uuid) {
+    public MomoApiResponse<List<String>> findAttendeesOfMeeting(@PathVariable String uuid) {
         return new MomoApiResponse<>(attendeeService.findAll(uuid));
     }
 }

--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeControllerDocs.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeControllerDocs.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import kr.momo.controller.MomoApiResponse;
 import kr.momo.controller.annotation.ApiErrorResponse;
 import kr.momo.controller.annotation.ApiSuccessResponse;
@@ -40,4 +41,13 @@ public interface AttendeeControllerDocs {
     @Operation(summary = "참가자 로그아웃", description = "참가자 로그아웃 API 입니다.")
     @ApiSuccessResponse.Ok("로그아웃 성공")
     ResponseEntity<Void> logout(@PathVariable @Schema(description = "약속 UUID") String uuid);
+
+    @Operation(summary = "약속의 모든 참여자 조회", description = "약속의 모든 참여자를 조회하는 API 입니다.")
+    @ApiSuccessResponse.Ok("약속의 모든 참여자 조회")
+    @ApiErrorResponse.BadRequest("""
+            요청이 잘못되었습니다.
+            1. 유효하지 않은 UUID
+            """
+    )
+    MomoApiResponse<List<String>> findAttendeesOfMeeting(@PathVariable @Schema(description = "약속 UUID") String uuid);
 }

--- a/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = false)
 public class Attendee extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
+++ b/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
@@ -1,5 +1,6 @@
 package kr.momo.service.attendee;
 
+import java.util.List;
 import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.attendee.AttendeeName;
 import kr.momo.domain.attendee.AttendeePassword;
@@ -46,5 +47,15 @@ public class AttendeeService {
         Attendee attendee = new Attendee(meeting, name, password, Role.GUEST);
         attendeeRepository.save(attendee);
         return AttendeeLoginResponse.from(jwtManager.generate(attendee.getId()), attendee);
+    }
+
+    public List<String> findAll(String uuid) {
+        Meeting meeting = meetingRepository.findByUuid(uuid)
+                .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
+        List<Attendee> attendees = attendeeRepository.findAllByMeeting(meeting);
+
+        return attendees.stream()
+                .map(Attendee::name)
+                .toList();
     }
 }

--- a/backend/src/test/java/kr/momo/controller/attendee/AttendeeControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/attendee/AttendeeControllerTest.java
@@ -78,7 +78,8 @@ class AttendeeControllerTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .when().get("/api/v1/meetings/{uuid}/attendees", meeting.getUuid())
+                .pathParams("uuid", meeting.getUuid())
+                .when().get("/api/v1/meetings/{uuid}/attendees")
                 .then().log().all()
                 .assertThat()
                 .statusCode(HttpStatus.OK.value())

--- a/backend/src/test/java/kr/momo/controller/attendee/AttendeeControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/attendee/AttendeeControllerTest.java
@@ -1,6 +1,7 @@
 package kr.momo.controller.attendee;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
@@ -22,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 
 @IsolateDatabase
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -64,5 +66,22 @@ class AttendeeControllerTest {
                 () -> assertThat(jwtManager.extract(token)).isEqualTo(attendee.getId()),
                 () -> assertThat(hostName).isEqualTo(request.attendeeName())
         );
+    }
+
+    @DisplayName("미팅에 참여한 모든 참여자를 조회하고 200 OK 상태코드를 반환한다.")
+    @Test
+    void findInMeeting() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.COFFEE.create());
+        Attendee jazz = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
+        Attendee pero = attendeeRepository.save(AttendeeFixture.GUEST_PEDRO.create(meeting));
+        Attendee mark = attendeeRepository.save(AttendeeFixture.GUEST_MARK.create(meeting));
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().get("/api/v1/meetings/{uuid}/attendees", meeting.getUuid())
+                .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .body("data", hasItems(jazz.name(), pero.name(), mark.name()));
     }
 }

--- a/backend/src/test/java/kr/momo/service/attendee/AttendeeServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/attendee/AttendeeServiceTest.java
@@ -3,6 +3,7 @@ package kr.momo.service.attendee;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.attendee.AttendeeRepository;
 import kr.momo.domain.meeting.Meeting;
@@ -75,5 +76,17 @@ class AttendeeServiceTest {
         long finalCount = attendeeRepository.count();
 
         assertThat(finalCount).isEqualTo(initialCount);
+    }
+
+    @DisplayName("미팅에 해당하는 모든 참여자의 이름 리스트를 반환한다.")
+    @Test
+    void findAllAttendeeNames() {
+        Attendee jazz = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
+        Attendee pero = attendeeRepository.save(AttendeeFixture.GUEST_PEDRO.create(meeting));
+        Attendee mark = attendeeRepository.save(AttendeeFixture.GUEST_MARK.create(meeting));
+
+        List<String> attendeeNames = attendeeService.findAll(meeting.getUuid());
+
+        assertThat(attendeeNames).containsExactlyInAnyOrder(jazz.name(), pero.name(), mark.name());
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #182 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

미팅의 모든 참여자의 이름을 조회하는 기능을 구현했습니다.

API 형식
요청
```http
GET /api/v1/meetings/{uuid}/attendees
```

응답
```http
{
   "data" : ["daon", "mark"]
}
```

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

(1) 미팅의 uuid를 제공하면 uuid에 해당하는 미팅을 조회한 후, 해당 미팅의 모든 참여자의 이름을 반환하는 기능입니다. 이 기능에 대해서 로그인이 필요할지 의문입니다. (현재는 로그인하지 않습니다.)

(2) 컨트롤러와 서비스의 함수 명이 애매합니다. 혹시 괜찮은 메서드명 있다면 추천 부탁드립니다.
