### PR TITLE
[BE] 약속 정보 조회시 주최자의 이름을 함께 반환

### DIFF
--- a/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/Attendee.java
@@ -57,8 +57,12 @@ public class Attendee extends BaseEntity {
         this(meeting, new AttendeeName(name), new AttendeePassword(password), role);
     }
 
+    public boolean isHost() {
+        return role.isHost();
+    }
+
     public boolean isNotHost() {
-        return role.isNotHost();
+        return !isHost();
     }
 
     public void verifyPassword(AttendeePassword other) {

--- a/backend/src/main/java/kr/momo/domain/attendee/Role.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/Role.java
@@ -5,7 +5,7 @@ public enum Role {
     HOST,
     GUEST;
 
-    public boolean isNotHost() {
-        return !HOST.equals(this);
+    public boolean isHost() {
+        return HOST.equals(this);
     }
 }

--- a/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
@@ -11,7 +11,8 @@ public enum MeetingErrorCode implements ErrorCodeType {
     MEETING_UNLOCKED(HttpStatus.BAD_REQUEST, "약속이 잠겨있지 않아 수행할 수 없습니다."),
     ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이미 확정된 약속입니다."),
     INVALID_DATETIME_RANGE(HttpStatus.BAD_REQUEST, "날짜 또는 시간이 잘못되었습니다."),
-    PAST_NOT_PERMITTED(HttpStatus.BAD_REQUEST, "과거 날짜로는 약속을 생성할 수 없습니다.");
+    PAST_NOT_PERMITTED(HttpStatus.BAD_REQUEST, "과거 날짜로는 약속을 생성할 수 없습니다."),
+    MEETING_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "약속 정보를 불러오는데 실패했습니다. 약속을 다시 생성해주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
@@ -10,6 +10,8 @@ import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.availabledate.AvailableDate;
 import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
+import kr.momo.exception.MomoException;
+import kr.momo.exception.code.MeetingErrorCode;
 
 @Schema(description = "약속 정보 응답")
 public record MeetingResponse(
@@ -32,7 +34,10 @@ public record MeetingResponse(
         List<LocalDate> availableDates,
 
         @Schema(description = "참가자 이름 목록")
-        List<String> attendeeNames
+        List<String> attendeeNames,
+
+        @Schema(description = "약속 주최자 이름")
+        String hostName
 ) {
 
     public static MeetingResponse of(Meeting meeting, AvailableDates availableDates, List<Attendee> attendees) {
@@ -44,13 +49,20 @@ public record MeetingResponse(
                 .map(Attendee::name)
                 .toList();
 
+        String hostName = attendees.stream()
+                .filter(Attendee::isHost)
+                .map(Attendee::name)
+                .findFirst()
+                .orElseThrow(() -> new MomoException(MeetingErrorCode.MEETING_LOAD_FAILURE));
+
         return new MeetingResponse(
                 meeting.getName(),
                 meeting.startTimeslotTime(),
                 meeting.endTimeslotTime(),
                 meeting.isLocked(),
                 dates,
-                attendeeNames
+                attendeeNames,
+                hostName
         );
     }
 }

--- a/backend/src/test/java/kr/momo/domain/attendee/RoleTest.java
+++ b/backend/src/test/java/kr/momo/domain/attendee/RoleTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.params.provider.CsvSource;
 class RoleTest {
 
     @ParameterizedTest
-    @CsvSource(value = {"HOST,false", "GUEST,true"})
+    @CsvSource(value = {"HOST,true", "GUEST,false"})
     void isHost(Role given, boolean expected) {
-        boolean result = given.isNotHost();
+        boolean result = given.isHost();
 
         assertThat(result).isEqualTo(expected);
     }


### PR DESCRIPTION
## 관련 이슈

- resolves: #201 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

기존 약속 정보 조회 API 호출 시 응답에 약속 주최자 이름을 포함하였습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
