### PR TITLE
[FE] 약속 시간 선택 default endTime 수정

### DIFF
--- a/frontend/src/hooks/useTimeRangeDropdown/constants.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/constants.ts
@@ -1,5 +1,5 @@
 export const INITIAL_START_TIME = '00:00';
-export const INITIAL_END_TIME = '01:00';
+export const INITIAL_END_TIME = '24:00';
 
 export const MINIMUM_TIME = 0;
 export const MAXIMUM_TIME = 24;

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
@@ -31,9 +31,7 @@ export function generateEndTimeOptions(startTime: string) {
 
   for (let i = startHours + 1; i <= MAXIMUM_TIME; i++) {
     const label = formatHours(i).padStart(2, '0');
-
-    // 시간상 24시는 존재하지 않기 때문에 백엔드에서 오류가 발생. 따라서 오전 12:00으로 표현하지만, 서버에 00:00으로 전송(@낙타)
-    times.push({ value: `${String(i === 24 ? 0 : i).padStart(2, '0')}:00`, label: label + ':00' });
+    times.push({ value: `${String(i).padStart(2, '0')}:00`, label: label + ':00' });
   }
 
   return times;

--- a/frontend/src/pages/CreateMeetingPage/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/index.tsx
@@ -6,6 +6,7 @@ import Field from '@components/_common/Field';
 import Input from '@components/_common/Input';
 
 import useInput from '@hooks/useInput/useInput';
+import { INITIAL_END_TIME, INITIAL_START_TIME } from '@hooks/useTimeRangeDropdown/constants';
 import useTimeRangeDropdown from '@hooks/useTimeRangeDropdown/useTimeRangeDropdown';
 import {
   generateEndTimeOptions,
@@ -51,7 +52,8 @@ export default function CreateMeetingPage() {
       meetingName: meetingName,
       availableMeetingDates: selectedDates,
       meetingStartTime: startTime,
-      meetingEndTime: endTime,
+      // 시간상 24시는 존재하지 않기 때문에 백엔드에서 오류가 발생. 따라서 오전 12:00으로 표현하지만, 서버에 00:00으로 전송(@낙타)
+      meetingEndTime: endTime === INITIAL_END_TIME ? INITIAL_START_TIME : endTime,
     });
   };
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #216

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

> 노션 링크 : https://paper-mass-5ff.notion.site/endTime-76d6260270e94ee1aca5d84aa5f847ae?pvs=4

기존 로직과 이에 대한 문제점 -> 해결방안 순서대로 노션에 정리해두었습니다.

- endTime 초기값 변경
- endTime을 서버로 보낼 때 24:00라면 00:00로 보내도록 설정

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
