### PR TITLE
[FE] primary color 수정

### DIFF
--- a/frontend/src/styles/tokens/colors.ts
+++ b/frontend/src/styles/tokens/colors.ts
@@ -31,7 +31,7 @@ const PRIMITIVE_COLORS = {
 export const SEMANTIC_COLORS = {
   white: PRIMITIVE_COLORS.white,
   black: PRIMITIVE_COLORS.black,
-  primary: PRIMITIVE_COLORS.pink['300'],
+  primary: PRIMITIVE_COLORS.pink['500'],
   holiday: PRIMITIVE_COLORS.red,
   grey: {
     primary: PRIMITIVE_COLORS.grey['200'],


### PR DESCRIPTION
#FFBABC -> #FF8DA6

## 관련 이슈

- resolves: #220 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

### 기존 색상

300: `#FFBABC`

### 변경된 색상

500: `#FF8DA6`

### 변경된 이유

기존에 선택한 primary color의 색상이 500번의 색상이였으며, 색상이 연하다는 사용자 피드백이 있었습니다.

### 색상 비교

<figure class="half">
  <img title="기존 색상" src="https://github.com/user-attachments/assets/0a15b295-b51d-4b8d-b02b-752dab6dd8cc" />
  <img title="변경된 색상" src="https://github.com/user-attachments/assets/e7f12dbc-3ff5-496d-a439-41b5889f397b" />
  <figurecaption>좌: 기존 색상, 우: 변경된 색상</figurecaption>
</figure>



## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
