### PR TITLE
[BE] 확정 조회 문제 해결

### DIFF
--- a/backend/src/main/java/kr/momo/domain/meeting/ConfirmedMeeting.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/ConfirmedMeeting.java
@@ -57,15 +57,14 @@ public class ConfirmedMeeting extends BaseEntity {
                 .collect(groupingBy(Schedule::getAttendee, counting()));
 
         long confirmedTimeSlotCount = countTimeSlotOfConfirmedMeeting();
-
         return groupAttendeeByScheduleCount.keySet().stream()
                 .filter(key -> groupAttendeeByScheduleCount.get(key) == confirmedTimeSlotCount)
                 .toList();
     }
 
-    public boolean isScheduleWithinDateTimeRange(Schedule schedule) {
+    private boolean isScheduleWithinDateTimeRange(Schedule schedule) {
         LocalDateTime dateTime = schedule.dateTime();
-        return !(dateTime.isBefore(startDateTime) || dateTime.isAfter(endDateTime));
+        return !dateTime.isBefore(startDateTime) && dateTime.isBefore(endDateTime);
     }
 
     private long countTimeSlotOfConfirmedMeeting() {

--- a/backend/src/test/java/kr/momo/domain/meeting/ConfirmedMeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/ConfirmedMeetingTest.java
@@ -33,6 +33,7 @@ class ConfirmedMeetingTest {
         List<Schedule> schedules = List.of(
                 new Schedule(attendee1, new AvailableDate(today, meeting), Timeslot.TIME_0000),
                 new Schedule(attendee1, new AvailableDate(today, meeting), Timeslot.TIME_0030),
+                new Schedule(attendee1, new AvailableDate(today, meeting), Timeslot.TIME_0100),
                 new Schedule(attendee2, new AvailableDate(today, meeting), Timeslot.TIME_0000)
         );
 

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingConfirmServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingConfirmServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.List;
@@ -201,13 +202,16 @@ class MeetingConfirmServiceTest {
         schedules.add(new Schedule(attendee, today, Timeslot.TIME_0000));
         schedules.add(new Schedule(attendee, today, Timeslot.TIME_0030));
         schedules.add(new Schedule(attendee, today, Timeslot.TIME_0100));
+        schedules.add(new Schedule(attendee, today, Timeslot.TIME_0130));
         Attendee attendee2 = attendeeRepository.save(AttendeeFixture.GUEST_MARK.create(meeting));
         schedules.add(new Schedule(attendee2, today, Timeslot.TIME_0000));
         schedules.add(new Schedule(attendee2, today, Timeslot.TIME_0100));
         scheduleRepository.saveAll(schedules);
-        MeetingConfirmResponse confirmed = meetingConfirmService.create(
-                meeting.getUuid(), attendee.getId(), validRequest
+        validRequest = new MeetingConfirmRequest(
+                today.getDate(), LocalTime.of(0, 0),
+                today.getDate(), LocalTime.of(1, 30)
         );
+        MeetingConfirmResponse confirmed = meetingConfirmService.create(meeting.getUuid(), attendee.getId(), validRequest);
 
         ConfirmedMeetingResponse response = meetingConfirmService.findByUuid(meeting.getUuid());
 


### PR DESCRIPTION
## 관련 이슈

- resolves: #215 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- 스케줄이 확정 일정 범위에 해당하는지 확인하는 메서드의 문제를 해결했습니다.
  - 스케줄의 Timeslot은 확정 일정의 시작 시간에 inclusive 합니다.
  - 확정 일정의 끝 시간은 TimeSlot의 개념이 아니므로 exclusive 합니다.   
  => [시작 시간, 끝 시간)
- 기존 잘못된 로직이 테스트를 통과하지 못하도록 수정했습니다.

## 특이 사항

```java
LocalDateTime dateTime = schedule.dateTime();
// 이전 코드 return !dateTime.isBefore(startDateTime) && !dateTime.isAfter(endDateTime);  [시작 시간, 끝 시간] X
return !dateTime.isBefore(startDateTime) && dateTime.isBefore(endDateTime); //  [시작 시간, 끝 시간) O
```

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
