### PR TITLE
[BE] N+1 Query 문제를 해결

### DIFF
--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
@@ -2,12 +2,15 @@ package kr.momo.domain.schedule;
 
 import java.util.List;
 import kr.momo.domain.attendee.Attendee;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+    @EntityGraph(attributePaths = {"availableDate"})
     List<Schedule> findAllByAttendee(Attendee attendee);
 
+    @EntityGraph(attributePaths = {"availableDate"})
     List<Schedule> findAllByAttendeeIn(List<Attendee> attendees);
 
     void deleteAllByAttendee(Attendee attendee);


### PR DESCRIPTION
## 관련 이슈

- resolves: #210 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

API 호출 시 쿼리가 N+1 번 호출되는 문제를 확인하고 이를 Fetch Join으로 해결하였습니다.
N+1 문제가 발생하는 API는 다음과 같습니다.

**약속 추천 기능은 현재 고려대상에서 제외하였습니다.**

- ScheduleService
    - findAllSchedules
    - findSingleSchedule
    - findMySchedule

위 메서드 모두 ScheduleRepository를 통해 List<Schedule>을 조회하여 Dto로 변환하는 과정에서 문제가 발생합니다.
`List<Schedule>`를 조회하기 위해 SQL을 1번, Schedule의 `AvailableDate`를 참조할 때 마다 SQL이 호출되어 N+1입니다.

ScheduleRepository의 `findAllByAttendee()`, `findAllByAttendeeIn()` 메서드에 `@EntityGraph`를 사용해서 항상 `AvailableDate`를 함께 조회할 수 있도록 하였습니다.

`findAllByAttendeeIn()` 같은 경우 현재 약속 추천 기능에도 사용되고 있지만
약속 추천 기능이 현재 완전하지 않으므로 `findAllByAttendeeIn()`를 별도의 fetch join 메서드로 분리하지는 않았습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

`JOIN FETCH`와 `@EntityGrpah`의 차이는 각각 inner join과 left outer join으로 동작하는 차이이며
직접 JPQL로 JOIN FETCH를 사용하여 해결해도 되지만, 간단한 EntityGrpah 어노테이션으로 문제를 해결하였습니다.

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
