### PR TITLE
[BE] 약속 생성 완료 시 생성된 약속의 정보를 응답

### DIFF
--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
@@ -64,4 +64,10 @@ public class AvailableDates {
     private boolean isNotDateCountEqual(LocalDate startDateInclusive, LocalDate endDateInclusive, long count) {
         return count != endDateInclusive.toEpochDay() - startDateInclusive.toEpochDay() + 1;
     }
+
+    public List<LocalDate> asList() {
+        return availableDates.stream()
+                .map(AvailableDate::getDate)
+                .toList();
+    }
 }

--- a/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
@@ -64,11 +64,11 @@ public class Meeting extends BaseEntity {
         return timeslotInterval.getValidatedTimeslot(other);
     }
 
-    public LocalTime startTimeslotTime() {
-        return timeslotInterval.getStartTimeslot().getLocalTime();
+    public LocalTime earliestTime() {
+        return timeslotInterval.getStartTimeslot().startTime();
     }
 
-    public LocalTime endTimeslotTime() {
-        return timeslotInterval.getEndTimeslot().getLocalTime();
+    public LocalTime lastTime() {
+        return timeslotInterval.getEndTimeslot().endTime();
     }
 }

--- a/backend/src/main/java/kr/momo/domain/timeslot/Timeslot.java
+++ b/backend/src/main/java/kr/momo/domain/timeslot/Timeslot.java
@@ -1,6 +1,8 @@
 package kr.momo.domain.timeslot;
 
+import java.time.Duration;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.TimeslotErrorCode;
@@ -77,5 +79,15 @@ public enum Timeslot {
 
     public boolean isBefore(LocalTime other) {
         return this.localTime.isBefore(other);
+    }
+
+    public LocalTime startTime() {
+        return localTime;
+    }
+
+    public LocalTime endTime() {
+        int slotLength = Timeslot.values().length;
+        Duration duration = ChronoUnit.DAYS.getDuration().dividedBy(slotLength);
+        return localTime.plusSeconds(duration.getSeconds());
     }
 }

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingCreateResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingCreateResponse.java
@@ -1,8 +1,14 @@
 package kr.momo.service.meeting.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import kr.momo.domain.attendee.Attendee;
+import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
 
 @Schema(description = "약속 생성 응답")
@@ -11,13 +17,36 @@ public record MeetingCreateResponse(
         @Schema(description = "약속 UUID")
         String uuid,
 
+        @Schema(description = "약속 이름")
+        String meetingName,
+
         @Schema(description = "호스트 이름")
         String hostName,
+
+        @Schema(description = "선택 가능 날짜")
+        List<LocalDate> availableDates,
+
+        @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+        @Schema(description = "선택 가능한 가장 이른 시각")
+        LocalTime earliestTime,
+
+        @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+        @Schema(description = "선택 가능한 가장 늦은 시각")
+        LocalTime lastTime,
 
         @JsonIgnore
         String token
 ) {
-    public static MeetingCreateResponse from(Meeting meeting, Attendee attendee, String token) {
-        return new MeetingCreateResponse(meeting.getUuid(), attendee.name(), token);
+
+    public static MeetingCreateResponse from(Meeting meeting, Attendee host, AvailableDates dates, String token) {
+        return new MeetingCreateResponse(
+                meeting.getUuid(),
+                meeting.getName(),
+                host.name(),
+                dates.asList(),
+                meeting.earliestTime(),
+                meeting.lastTime(),
+                token
+        );
     }
 }

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingCreateResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingCreateResponse.java
@@ -27,11 +27,11 @@ public record MeetingCreateResponse(
         List<LocalDate> availableDates,
 
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-        @Schema(description = "선택 가능한 가장 이른 시각")
+        @Schema(type = "String", pattern = "HH:mm", description = "선택 가능한 가장 이른 시각")
         LocalTime earliestTime,
 
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-        @Schema(description = "선택 가능한 가장 늦은 시각")
+        @Schema(type = "String", pattern = "HH:mm", description = "선택 가능한 가장 늦은 시각")
         LocalTime lastTime,
 
         @JsonIgnore

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
@@ -20,11 +20,11 @@ public record MeetingResponse(
         String meetingName,
 
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-        @Schema(type = "string", pattern = "HH:mm", description = "약속 시작 시간")
+        @Schema(type = "string", pattern = "HH:mm", description = "약속 시작 시각")
         LocalTime firstTime,
 
         @JsonFormat(shape = Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-        @Schema(type = "string", pattern = "HH:mm", description = "약속 종료 시간")
+        @Schema(type = "string", pattern = "HH:mm", description = "약속 종료 시각")
         LocalTime lastTime,
 
         @Schema(description = "약속 잠금 여부")
@@ -57,8 +57,8 @@ public record MeetingResponse(
 
         return new MeetingResponse(
                 meeting.getName(),
-                meeting.startTimeslotTime(),
-                meeting.endTimeslotTime(),
+                meeting.earliestTime(),
+                meeting.lastTime(),
                 meeting.isLocked(),
                 dates,
                 attendeeNames,

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -83,8 +83,8 @@ class MeetingControllerTest {
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
             softAssertions.assertThat(meetingName).isEqualTo(meeting.getName());
-            softAssertions.assertThat(firstTime).isEqualTo(meeting.startTimeslotTime().toString());
-            softAssertions.assertThat(lastTime).isEqualTo(meeting.endTimeslotTime().toString());
+            softAssertions.assertThat(firstTime).isEqualTo(meeting.earliestTime().toString());
+            softAssertions.assertThat(lastTime).isEqualTo(meeting.lastTime().toString());
             softAssertions.assertThat(availableDatesList).containsExactlyElementsOf(dates);
             softAssertions.assertThat(attendeeNamesList).containsExactlyElementsOf(attendeeNames);
         });

--- a/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
@@ -62,7 +62,8 @@ class MeetingTest {
         Meeting meeting = new Meeting("momo", "momo", startTime, endTime);
 
         // then
-        assertThat(meeting.endTimeslotTime()).isEqualTo(endTime.minusMinutes(30));
+        LocalTime meetingLastTimeSlotRepresentative = meeting.getTimeslotInterval().getEndTimeslot().getLocalTime();
+        assertThat(meetingLastTimeSlotRepresentative).isEqualTo(endTime.minusMinutes(30));
     }
 
     @DisplayName("약속을 잠근다.")

--- a/backend/src/test/java/kr/momo/domain/timeslot/TimeslotTest.java
+++ b/backend/src/test/java/kr/momo/domain/timeslot/TimeslotTest.java
@@ -30,4 +30,31 @@ class TimeslotTest {
 
         assertThat(timeslot.getLocalTime()).isEqualTo(localTime);
     }
+
+
+    @DisplayName("시간슬롯의 시작 시각은 해당 슬롯의 대표값과 같다.")
+    @Test
+    void timeSlotStartTime() {
+        // given
+        Timeslot timeslot = Timeslot.TIME_0130;
+
+        // when
+        LocalTime startTime = timeslot.startTime();
+
+        // then
+        assertThat(startTime).isEqualTo(LocalTime.of(1, 30));
+    }
+
+    @DisplayName("시간슬롯의 끝 시각은 해당 슬롯의 대표값에 슬롯 길이를 더한 시각과 같다.")
+    @Test
+    void timeSlotEndTime() {
+        // given
+        Timeslot timeslot = Timeslot.TIME_2330;
+
+        // when
+        LocalTime endTime = timeslot.endTime();
+
+        // then
+        assertThat(endTime).isEqualTo(LocalTime.of(0, 0));
+    }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingConfirmServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingConfirmServiceTest.java
@@ -73,8 +73,8 @@ class MeetingConfirmServiceTest {
         attendee = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(this.meeting));
         today = availableDateRepository.save(new AvailableDate(LocalDate.now(), this.meeting));
         validRequest = new MeetingConfirmRequest(
-                today.getDate(), meeting.startTimeslotTime(),
-                today.getDate(), meeting.startTimeslotTime().plusMinutes(90)
+                today.getDate(), meeting.earliestTime(),
+                today.getDate(), meeting.earliestTime().plusMinutes(90)
         );
     }
 
@@ -106,8 +106,8 @@ class MeetingConfirmServiceTest {
     @DisplayName("존재하지 않은 참가자가 잠겨있는 약속 일정을 확정 시 예외가 발생한다.")
     @Test
     void confirmScheduleThrowsExceptionWhen_InvalidAttendee() {
-        long InvalidAttendeeId = 9999L;
-        assertThatThrownBy(() -> meetingConfirmService.create(meeting.getUuid(), InvalidAttendeeId, validRequest))
+        long invalidAttendeeId = 9999L;
+        assertThatThrownBy(() -> meetingConfirmService.create(meeting.getUuid(), invalidAttendeeId, validRequest))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AttendeeErrorCode.INVALID_ATTENDEE.message());
     }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -70,8 +70,8 @@ class MeetingServiceTest {
         MeetingResponse response = meetingService.findByUUID(meeting.getUuid());
 
         assertAll(
-                () -> assertThat(response.firstTime()).isEqualTo(meeting.startTimeslotTime()),
-                () -> assertThat(response.lastTime()).isEqualTo(meeting.endTimeslotTime()),
+                () -> assertThat(response.firstTime()).isEqualTo(meeting.earliestTime()),
+                () -> assertThat(response.lastTime()).isEqualTo(meeting.lastTime()),
                 () -> assertThat(response.meetingName()).isEqualTo(meeting.getName()),
                 () -> assertThat(response.isLocked()).isFalse(),
                 () -> assertThat(response.availableDates()).hasSize(availableDates.size()),


### PR DESCRIPTION
## 관련 이슈

- resolves: #225 

## 작업 내용

약속 생성 완료 시 생성된 약속에 대한 정보들을 응답합니다.
약속 생성 완료 화면에서 사용자의 입력이 제대로 저장되었다는 UI를 표시하기 위해 사용합니다.

## 특이 사항
- `Timeslot` 에 각 슬롯의 시작 시각과 끝 시각을 반환하는 메서드를 추가했습니다.
- 메서드의 의미를 반영하여 `Meeting`의 `startTimeSlotTime()` 과 `endTimeSlotTime()` 이 각각 `earliestTime()`, `lastTime()` 으로 변경되었습니다.
- `Timeslot`의 `localTime` 필드는 해당 슬롯의 '대푯값' 으로만 사용됩니다. 의미 있는 값을 참조하기 위해서는 `Timeslot.startTime()` 과 `Timeslot.endTime()` 으로 참조해 주세요

**현재 DTO 응답 시 날짜 정보를 정렬해서 응답하지 않습니다.** `TreeSet` 으로 일괄 변경하면 좋을 것 같은데, 다른 브랜치에서 작업하는게 좋을 것 같아 다음 이슈 파서 작업할게요~

## 리뷰 요구사항 (선택)

cc. @Largopie 
