### PR TITLE
[BE] AvailableDates가 내부적으로 정렬된 상태를 유지하도록 개선

### DIFF
--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDateRepository.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDateRepository.java
@@ -7,6 +7,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
 
     List<AvailableDate> findAllByMeeting(Meeting meeting);
-
-    List<AvailableDate> findAllByMeetingOrderByDate(Meeting meeting);
 }

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
@@ -40,8 +40,8 @@ public class AvailableDates {
     }
 
     public boolean notExistsByDate(LocalDate other) {
-        return availableDates.stream()
-                .noneMatch(availableDate -> availableDate.isSameDate(other));
+        Meeting meeting = availableDates.first().getMeeting();
+        return !availableDates.contains(new AvailableDate(other, meeting));
     }
 
     public boolean isNotConsecutiveDay(LocalDate startDateInclusive, LocalDate endDateInclusive) {

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
@@ -1,11 +1,11 @@
 package kr.momo.domain.availabledate;
 
-import static java.util.Comparator.comparing;
-
 import java.time.LocalDate;
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 import kr.momo.domain.meeting.Meeting;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.AvailableDateErrorCode;
@@ -14,24 +14,17 @@ import lombok.Getter;
 @Getter
 public class AvailableDates {
 
-    private final List<AvailableDate> availableDates;
+    private final SortedSet<AvailableDate> availableDates;
 
     public AvailableDates(List<LocalDate> dates, Meeting meeting) {
-        validateUniqueDates(dates);
         this.availableDates = dates.stream()
                 .map(date -> new AvailableDate(date, meeting))
-                .toList();
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(AvailableDate::getDate))));
     }
 
     public AvailableDates(List<AvailableDate> availableDates) {
-        this.availableDates = availableDates;
-    }
-
-    private void validateUniqueDates(List<LocalDate> dates) {
-        Set<LocalDate> dateSet = new HashSet<>(dates);
-        if (dateSet.size() != dates.size()) {
-            throw new MomoException(AvailableDateErrorCode.DUPLICATED_DATE);
-        }
+        this.availableDates = availableDates.stream()
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(AvailableDate::getDate))));
     }
 
     public boolean isAnyBefore(LocalDate other) {
@@ -53,7 +46,6 @@ public class AvailableDates {
 
     public boolean isNotConsecutiveDay(LocalDate startDateInclusive, LocalDate endDateInclusive) {
         long availableDateRangeCount = availableDates.stream()
-                .sorted(comparing(AvailableDate::getDate))
                 .dropWhile(date -> date.isBefore(startDateInclusive))
                 .takeWhile(date -> !date.isAfter(endDateInclusive))
                 .count();

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDates.java
@@ -28,8 +28,8 @@ public class AvailableDates {
     }
 
     public boolean isAnyBefore(LocalDate other) {
-        return availableDates.stream()
-                .anyMatch(date -> date.isBefore(other));
+        LocalDate minimumDate = availableDates.first().getDate();
+        return minimumDate.isBefore(other);
     }
 
     public AvailableDate findByDate(LocalDate other) {

--- a/backend/src/main/java/kr/momo/domain/schedule/Schedule.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/Schedule.java
@@ -53,7 +53,7 @@ public class Schedule extends BaseEntity {
     }
 
     public LocalDateTime dateTime() {
-        return LocalDateTime.of(availableDate.getDate(), timeslot.getLocalTime());
+        return LocalDateTime.of(availableDate.getDate(), timeslot.startTime());
     }
 
     public LocalDate date() {
@@ -61,7 +61,7 @@ public class Schedule extends BaseEntity {
     }
 
     public LocalTime time() {
-        return timeslot.getLocalTime();
+        return timeslot.startTime();
     }
 
     public String attendeeName() {

--- a/backend/src/main/java/kr/momo/domain/timeslot/Timeslot.java
+++ b/backend/src/main/java/kr/momo/domain/timeslot/Timeslot.java
@@ -6,9 +6,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.TimeslotErrorCode;
-import lombok.Getter;
 
-@Getter
 public enum Timeslot {
 
     TIME_0000(LocalTime.of(0, 0)),
@@ -60,34 +58,39 @@ public enum Timeslot {
     TIME_2300(LocalTime.of(23, 0)),
     TIME_2330(LocalTime.of(23, 30));
 
-    private final LocalTime localTime;
+    private static final long DURATION_IN_MINUTE;
+    private final LocalTime startTime;
 
-    Timeslot(LocalTime localTime) {
-        this.localTime = localTime;
+    static {
+        int slotCount = Timeslot.values().length;
+        Duration duration = ChronoUnit.DAYS.getDuration().dividedBy(slotCount);
+        DURATION_IN_MINUTE = duration.toMinutes();
+    }
+
+    Timeslot(LocalTime startTime) {
+        this.startTime = startTime;
     }
 
     public static Timeslot from(LocalTime localTime) {
         return Arrays.stream(values())
-                .filter(timeslot -> timeslot.localTime.equals(localTime))
+                .filter(timeslot -> timeslot.startTime.equals(localTime))
                 .findAny()
                 .orElseThrow(() -> new MomoException(TimeslotErrorCode.INVALID_TIMESLOT));
     }
 
     public boolean isAfter(LocalTime other) {
-        return this.localTime.isAfter(other);
+        return this.startTime.isAfter(other);
     }
 
     public boolean isBefore(LocalTime other) {
-        return this.localTime.isBefore(other);
+        return this.startTime.isBefore(other);
     }
 
     public LocalTime startTime() {
-        return localTime;
+        return startTime;
     }
 
     public LocalTime endTime() {
-        int slotLength = Timeslot.values().length;
-        Duration duration = ChronoUnit.DAYS.getDuration().dividedBy(slotLength);
-        return localTime.plusSeconds(duration.getSeconds());
+        return startTime.plusMinutes(DURATION_IN_MINUTE);
     }
 }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -71,9 +71,7 @@ public class MeetingService {
     public MeetingResponse findByUUID(String uuid) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
-        AvailableDates availableDates = new AvailableDates(
-                availableDateRepository.findAllByMeeting(meeting)
-        );
+        AvailableDates availableDates = new AvailableDates(availableDateRepository.findAllByMeeting(meeting));
         List<Attendee> attendees = attendeeRepository.findAllByMeeting(meeting);
 
         return MeetingResponse.of(meeting, availableDates, attendees);

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -72,7 +72,7 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
         AvailableDates availableDates = new AvailableDates(
-                availableDateRepository.findAllByMeetingOrderByDate(meeting)
+                availableDateRepository.findAllByMeeting(meeting)
         );
         List<Attendee> attendees = attendeeRepository.findAllByMeeting(meeting);
 

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
@@ -41,9 +41,7 @@ public record MeetingResponse(
 ) {
 
     public static MeetingResponse of(Meeting meeting, AvailableDates availableDates, List<Attendee> attendees) {
-        List<LocalDate> dates = availableDates.getAvailableDates().stream()
-                .map(AvailableDate::getDate)
-                .toList();
+        List<LocalDate> dates = availableDates.asList();
 
         List<String> attendeeNames = attendees.stream()
                 .map(Attendee::name)

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingResponse.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import kr.momo.domain.attendee.Attendee;
-import kr.momo.domain.availabledate.AvailableDate;
 import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
 import kr.momo.exception.MomoException;

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -136,29 +136,6 @@ class MeetingControllerTest {
                 .header(HttpHeaders.LOCATION, containsString("/meeting/"));
     }
 
-    @DisplayName("약속을 생성할 때 중복되는 날짜로 요청하면 400을 반환한다.")
-    @Test
-    void createByDuplicatedName() {
-        LocalDate today = LocalDate.now();
-        LocalDate tomorrow = today.plusDays(1);
-        MeetingCreateRequest request = new MeetingCreateRequest(
-                "momoHost",
-                "momo",
-                "momoMeeting",
-                List.of(tomorrow, tomorrow),
-                LocalTime.of(8, 0),
-                LocalTime.of(22, 0)
-        );
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when().post("/api/v1/meetings")
-                .then().log().all()
-                .assertThat()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-    }
-
     @DisplayName("약속을 잠그면 200 OK를 반환한다.")
     @Test
     void lock() {

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -401,8 +401,8 @@ class MeetingControllerTest {
 
     private MeetingConfirmRequest getValidFindRequest(AvailableDate tomorrow) {
         return new MeetingConfirmRequest(
-                tomorrow.getDate(), Timeslot.TIME_0000.getLocalTime(),
-                tomorrow.getDate(), Timeslot.TIME_0600.getLocalTime()
+                tomorrow.getDate(), Timeslot.TIME_0000.startTime(),
+                tomorrow.getDate(), Timeslot.TIME_0600.startTime()
         );
     }
 }

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -78,7 +78,7 @@ class ScheduleControllerTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract().cookie("ACCESS_TOKEN");
 
-        List<LocalTime> times = List.of(Timeslot.TIME_0100.getLocalTime(), Timeslot.TIME_0130.getLocalTime());
+        List<LocalTime> times = List.of(Timeslot.TIME_0100.startTime(), Timeslot.TIME_0130.startTime());
         List<DateTimesCreateRequest> dateTimes = List.of(
                 new DateTimesCreateRequest(today.getDate(), times),
                 new DateTimesCreateRequest(tomorrow.getDate(), times)

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
@@ -3,6 +3,7 @@ package kr.momo.domain.availabledate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -147,5 +148,27 @@ class AvailableDatesTest {
         // then
         List<LocalDate> expected = actual.stream().sorted().toList();
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("날짜 필드의 값만으로 존재 여부를 판단한다.")
+    @Test
+    void notExistsByDate() {
+        // given
+        Meeting meeting = MeetingFixture.GAME.create();
+        LocalDate today = LocalDate.now();
+        AvailableDate availableDate1 = new AvailableDate(today.minusDays(1), meeting);
+        AvailableDate availableDate2 = new AvailableDate(today.minusDays(2), meeting);
+        AvailableDate availableDate3 = new AvailableDate(today.minusDays(3), meeting);
+        AvailableDates availableDates = new AvailableDates(List.of(availableDate1, availableDate2, availableDate3));
+
+        // when
+        LocalDate anotherToday = LocalDate.now();
+
+        // then
+        assertAll(
+                () -> assertThat(availableDates.notExistsByDate(anotherToday)).isTrue(),
+                () -> assertThat(availableDates.notExistsByDate(anotherToday.minusDays(3))).isFalse(),
+                () -> assertThat(availableDates.notExistsByDate(anotherToday.minusDays(4))).isTrue()
+        );
     }
 }

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
@@ -128,4 +128,24 @@ class AvailableDatesTest {
                         true)
         );
     }
+
+    @DisplayName("정렬되지 않은 순으로 날짜를 전달해도 정렬된 상태로 반환한다.")
+    @Test
+    void sortedAvailableDates() {
+        // given
+        LocalDate today = LocalDate.now();
+        List<LocalDate> dates = List.of(
+                today.plusDays(3),
+                today.plusDays(1),
+                today.plusDays(2)
+        );
+        AvailableDates availableDates = new AvailableDates(dates, MeetingFixture.GAME.create());
+
+        // when
+        List<LocalDate> actual = availableDates.asList();
+
+        // then
+        List<LocalDate> expected = actual.stream().sorted().toList();
+        assertThat(actual).isEqualTo(expected);
+    }
 }

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDatesTest.java
@@ -54,20 +54,6 @@ class AvailableDatesTest {
         assertThat(availableDate.getDate()).isEqualTo(tomorrow);
     }
 
-    @DisplayName("가능한 시간의 값이 중복이면 예외가 발생한다.")
-    @Test
-    void throwExceptionWhenDuplicatedDate() {
-        // given
-        Meeting meeting = MeetingFixture.GAME.create();
-        LocalDate date = LocalDate.of(2024, 7, 24);
-        List<LocalDate> dates = List.of(date, date);
-
-        // when then
-        assertThatThrownBy(() -> new AvailableDates(dates, meeting))
-                .isInstanceOf(MomoException.class)
-                .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
-    }
-
     @DisplayName("가능한 시간이 중복이 아니면 예외가 발생하지 않는다.")
     @Test
     void createAvailableDates() {

--- a/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/MeetingTest.java
@@ -62,7 +62,7 @@ class MeetingTest {
         Meeting meeting = new Meeting("momo", "momo", startTime, endTime);
 
         // then
-        LocalTime meetingLastTimeSlotRepresentative = meeting.getTimeslotInterval().getEndTimeslot().getLocalTime();
+        LocalTime meetingLastTimeSlotRepresentative = meeting.getTimeslotInterval().getEndTimeslot().startTime();
         assertThat(meetingLastTimeSlotRepresentative).isEqualTo(endTime.minusMinutes(30));
     }
 

--- a/backend/src/test/java/kr/momo/domain/timeslot/TimeslotIntervalTest.java
+++ b/backend/src/test/java/kr/momo/domain/timeslot/TimeslotIntervalTest.java
@@ -18,9 +18,9 @@ class TimeslotIntervalTest {
 
     @DisplayName("주어진 시간이 시간슬롯 인터벌에 포함되어 있지 않으면 예외를 발생시킨다.")
     @Test
-    public void throwsExceptionIfNotContainingInterval() {
+    void throwsExceptionIfNotContainingInterval() {
         TimeslotInterval timeslotInterval = new TimeslotInterval(Timeslot.TIME_1000, Timeslot.TIME_1800);
-        LocalTime other = Timeslot.TIME_0900.getLocalTime();
+        LocalTime other = Timeslot.TIME_0900.startTime();
 
         assertThatThrownBy(() -> timeslotInterval.getValidatedTimeslot(other))
                 .isInstanceOf(MomoException.class)
@@ -29,18 +29,18 @@ class TimeslotIntervalTest {
 
     @DisplayName("주어진 시간이 시간슬롯 인터벌에 포함되어 있으면 일치하는 타임슬롯을 반환한다.")
     @Test
-    public void successfulWhenContainingIntervalFully() {
+    void successfulWhenContainingIntervalFully() {
         TimeslotInterval timeslotInterval = new TimeslotInterval(Timeslot.TIME_1000, Timeslot.TIME_1800);
-        LocalTime other = Timeslot.TIME_1200.getLocalTime();
+        LocalTime other = Timeslot.TIME_1200.startTime();
 
         Timeslot timeslot = timeslotInterval.getValidatedTimeslot(other);
 
-        assertThat(timeslot.getLocalTime()).isEqualTo(other);
+        assertThat(timeslot.startTime()).isEqualTo(other);
     }
 
     @DisplayName("시작 끝이 같은 시간에 대한 시간슬롯 인터벌을 생성할 수 있다.")
     @Test
-    public void successfulCreationForSameStartAndEndTime() {
+    void successfulCreationForSameStartAndEndTime() {
         assertThatNoException()
                 .isThrownBy(() -> new TimeslotInterval(LocalTime.of(23, 30), LocalTime.of(23, 30)));
     }

--- a/backend/src/test/java/kr/momo/domain/timeslot/TimeslotTest.java
+++ b/backend/src/test/java/kr/momo/domain/timeslot/TimeslotTest.java
@@ -24,11 +24,11 @@ class TimeslotTest {
     @DisplayName("주어진 시간에 해당하는 시간슬롯이 존재하면 해당 시간슬롯을 반환한다.")
     @Test
     void successfulWhenTimeslotExists() {
-        LocalTime localTime = Timeslot.TIME_1200.getLocalTime();
+        LocalTime localTime = Timeslot.TIME_1200.startTime();
 
         Timeslot timeslot = Timeslot.from(localTime);
 
-        assertThat(timeslot.getLocalTime()).isEqualTo(localTime);
+        assertThat(timeslot.startTime()).isEqualTo(localTime);
     }
 
 

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingConfirmServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingConfirmServiceTest.java
@@ -148,8 +148,8 @@ class MeetingConfirmServiceTest {
     void confirmScheduleThrowsExceptionWhen_InvalidDate() {
         LocalDate invalidDate = LocalDate.now().plusDays(30);
         MeetingConfirmRequest request = new MeetingConfirmRequest(
-                invalidDate, Timeslot.TIME_0100.getLocalTime(),
-                invalidDate, Timeslot.TIME_0130.getLocalTime()
+                invalidDate, Timeslot.TIME_0100.startTime(),
+                invalidDate, Timeslot.TIME_0130.startTime()
         );
 
         assertThatThrownBy(() -> meetingConfirmService.create(meeting.getUuid(), attendee.getId(), request))
@@ -161,8 +161,8 @@ class MeetingConfirmServiceTest {
     @Test
     void confirmScheduleThrowsExceptionWhen_InvalidTime() {
         MeetingConfirmRequest request = new MeetingConfirmRequest(
-                today.getDate(), Timeslot.TIME_2200.getLocalTime(),
-                today.getDate(), Timeslot.TIME_2300.getLocalTime()
+                today.getDate(), Timeslot.TIME_2200.startTime(),
+                today.getDate(), Timeslot.TIME_2300.startTime()
         );
 
         assertThatThrownBy(() -> meetingConfirmService.create(meeting.getUuid(), attendee.getId(), request))

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -19,7 +19,6 @@ import kr.momo.domain.meeting.Meeting;
 import kr.momo.domain.meeting.MeetingRepository;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.AttendeeErrorCode;
-import kr.momo.exception.code.AvailableDateErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.fixture.AttendeeFixture;
 import kr.momo.fixture.MeetingFixture;
@@ -99,27 +98,6 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.findMeetingSharing(invalidUUID))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(MeetingErrorCode.INVALID_UUID.message());
-    }
-
-    @DisplayName("약속을 생성할 때 같은 약속일을 2번 이상 보내면 예외가 발생합니다.")
-    @Test
-    void throwExceptionWhenDuplicatedDates() {
-        //given
-        setFixedClock();
-        LocalDate today = LocalDate.now(clock);
-        MeetingCreateRequest request = new MeetingCreateRequest(
-                "momoHost",
-                "momo",
-                "momoMeeting",
-                List.of(today, today),
-                LocalTime.of(8, 0),
-                LocalTime.of(22, 0)
-        );
-
-        //when //then
-        assertThatThrownBy(() -> meetingService.create(request))
-                .isInstanceOf(MomoException.class)
-                .hasMessage(AvailableDateErrorCode.DUPLICATED_DATE.message());
     }
 
     @DisplayName("약속을 생성할 때 과거 날짜를 보내면 예외가 발생합니다.")

--- a/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
@@ -74,7 +74,7 @@ class ScheduleServiceTest {
         today = availableDateRepository.save(new AvailableDate(LocalDate.now(), meeting));
         tomorrow = availableDateRepository.save(new AvailableDate(LocalDate.now().plusDays(1), meeting));
 
-        List<LocalTime> times = List.of(Timeslot.TIME_0100.getLocalTime(), Timeslot.TIME_0130.getLocalTime());
+        List<LocalTime> times = List.of(Timeslot.TIME_0100.startTime(), Timeslot.TIME_0130.startTime());
 
         dateTimes = List.of(
                 new DateTimesCreateRequest(today.getDate(), times),
@@ -147,15 +147,15 @@ class ScheduleServiceTest {
         assertThat(response.schedules()).containsExactlyInAnyOrder(
                 new AttendeesScheduleResponse(
                         today.getDate(),
-                        Timeslot.TIME_0100.getLocalTime(),
+                        Timeslot.TIME_0100.startTime(),
                         List.of(attendee.name(), attendee2.name())),
                 new AttendeesScheduleResponse(
                         today.getDate(),
-                        Timeslot.TIME_0130.getLocalTime(),
+                        Timeslot.TIME_0130.startTime(),
                         List.of(attendee2.name())),
                 new AttendeesScheduleResponse(
                         tomorrow.getDate(),
-                        Timeslot.TIME_0100.getLocalTime(),
+                        Timeslot.TIME_0100.startTime(),
                         List.of(attendee.name()))
         );
     }
@@ -245,53 +245,53 @@ class ScheduleServiceTest {
 
         assertThat(responses).containsExactly(
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0100.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0130.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0100.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0130.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.startTime()),
                         new AttendeeGroup(List.of(daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0300.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0300.startTime()),
                         new AttendeeGroup(List.of(daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.startTime()),
                         new AttendeeGroup(List.of(daon))
                 )
         );
@@ -317,53 +317,53 @@ class ScheduleServiceTest {
 
         assertThat(responses).containsExactly(
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0100.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0130.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0100.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0130.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0230.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0330.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0400.startTime()),
                         new AttendeeGroup(List.of(daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0500.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_0630.startTime()),
                         new AttendeeGroup(List.of(daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0300.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0300.startTime()),
                         new AttendeeGroup(List.of(daon))
                 )
         );
@@ -388,38 +388,38 @@ class ScheduleServiceTest {
 
         assertThat(responses).containsExactly(
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_2300.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0030.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_2300.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0030.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
                         new AttendeeGroup(List.of(jazz, daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_2230.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_2230.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_1700.getLocalTime()),
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_1800.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_1700.startTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_1800.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0400.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0400.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0500.startTime()),
                         new AttendeeGroup(List.of(jazz))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(today.getDate(), Timeslot.TIME_2300.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0030.getLocalTime()),
+                        LocalDateTime.of(today.getDate(), Timeslot.TIME_2300.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0030.startTime()),
                         new AttendeeGroup(List.of(daon))
                 ),
                 RecommendedScheduleResponse.of(
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.getLocalTime()),
-                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0200.getLocalTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0130.startTime()),
+                        LocalDateTime.of(tomorrow.getDate(), Timeslot.TIME_0200.startTime()),
                         new AttendeeGroup(List.of(daon))
                 )
         );


### PR DESCRIPTION
## 관련 이슈

- resolves: #230 

## 작업 내용

`AvailableDate` 의 일급 컬렉션인 `AvailableDates` 가 내부 필드로 `List` 가 아닌 `SortedSet`을 가지고 있도록 변경했습니다.

그에 따라 리스트에서 `O(N)` 으로 동작하던 몇 연산들을 `O(1)` 혹은 `O(log N)`로 수행할 수 있도록 최적화했습니다.

## 특이 사항

자료구조 특성상 더 이상 중복된 값이 존재할 수 없으므로 중복 검증 로직과 테스트를 삭제했습니다.

## 리뷰 요구사항 (선택)

`AvailableDates`는 도메인이죠. 현재 흐름대로 사용한다면 (테스트코드를 제외하고는) 모두 같은 `Meeting`에 대한 `AvailableDate`들을 래핑하고 있어요.

이때, 생성자로 전달되는 각 `AvailableDate` 들이 같은 `Meeting`을 가지는지를 검증해야 할까요?
로직상에서 강제로 `Meeting`이 다른 `AvailableDate`를 리스트에 담고, 그 리스트를 기반으로 `AvailableDates`를 생성하지 않는 이상 서로 다른 Meeting을 가질 일이 전혀 없긴 해요.

개인적으로는 `AvailableDates`라는 객체를 같은 `Meeting`에 대한 `AvailableDate`의 컬렉션으로 정의했기 때문에, 강제 생성 케이스를 제외하고는 만들어질 일이 없다고 하더라도 검증을 추가하는게 좀 더 견고한 도메인이 될 수 있는 방향이라고 생각합니다.

하지만 검증 로직을 작성 중, 다음과 같은 의문이 남아 우선 검증을 추가하지 않은 상태입니다.
1. 현재 `List.of(new AvailableDates(new Meeting(..)..))` 과 같이 임시로 객체를 생성하여 일급컬렉션을 만드는 테스트코드의 일괄 수정 필요
2. 거의 모든 경우에 실패할 일이 없음에도 검증을 해야 하므로, 그것에서 오는 연산 오버헤드
3. 검증을 위해 `Meeting`의 비교가 필요한데, 엔티티 동등성 비교 기준의 모호함
    - PK를 기준으로? / PK가 null일 때는?
    - PK를 제외한 필드값들을 기준으로? / 동등성 비교만을 위해 필드를 다 꺼내 와야 하나?
    - 비즈니스 키를 정의하여 해당하는 필드 쌍을 기준으로?
        - 특정 문맥에서만 사용되는 동등성 비교 메서드 정의 (ex, `hasSameId()`)

검증은 다음과 같은 방식을 생각하고 있어요.
만약 검증을 한다고 하면, 이곳에서 검증에 실패한 경우 어떤 예외를 던져야 할까요?
이러한 유형의 검증은 사용자의 잘못된 입력을 검증하기보다는 도메인에서 개발자의 실수를 미연에 방지하기 위해 던지는 예외의 성격이 강한데요, 때문에 `MomoException`을 던지기에는 부적절하다고 생각했어요.
```java
    public AvailableDates(List<AvailableDate> availableDates) {
        Meeting allowedMeeting = availableDates.get(0).getMeeting();
        this.availableDates = availableDates.stream()
                .map(ad -> validateAllSameMeeting(ad, allowedMeeting))
                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(AvailableDate::getDate))));
    }

    private AvailableDate validateAllSameMeeting(AvailableDate availableDate, Meeting allowedMeeting) {
        long allowedMeetingId = allowedMeeting.getId();
        long thisId = availableDate.getMeeting().getId();
        if (allowedMeetingId != thisId) {
            throw new MomoException(???);  //  어떤 예외를 던질 것인가?
        }
        return availableDate;
    }
```


