### PR TITLE
[FE] CD 워크플로우에서 Self hosted runner 상세 태그 지정

### DIFF
--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -76,7 +76,7 @@ jobs:
 
   deploy:
     needs: fe-build
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, ARM64, dev]
     env:
       CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID}}
     steps:


### PR DESCRIPTION
## 관련 이슈

- resolves: #239

## 작업 내용

프론트엔드 CD 워크플로우의 self hosted runner 지정 구문에서 러너를 고유하게 식별할 수 있도록 다음과 같은 태그를 추가했습니다.

- self-hosted
- linux
- ARM64
- dev

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

핫픽스 브랜치라 빠른 머지 부탁드려요~
