### PR TITLE
[FE] 시간 범위 선택 Dropdown 컴포넌트 사용성 개선

### DIFF
--- a/frontend/src/components/TimeRangeSelector/TimeRangeSelector.styles.ts
+++ b/frontend/src/components/TimeRangeSelector/TimeRangeSelector.styles.ts
@@ -1,0 +1,7 @@
+import { css } from '@emotion/react';
+
+export const s_dropdownContainer = css`
+  display: flex;
+  gap: 1.2rem;
+  justify-content: flex-start;
+`;

--- a/frontend/src/components/TimeRangeSelector/TimeRangeSeletor.stories.tsx
+++ b/frontend/src/components/TimeRangeSelector/TimeRangeSeletor.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta } from '@storybook/react';
+
+import useTimeRangeDropdown from '@hooks/useTimeRangeDropdown/useTimeRangeDropdown';
+
+import TimeRangeSelector from '.';
+
+const meta = {
+  title: 'Components/TimeRangeSelector',
+  component: TimeRangeSelector,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+
+  decorators: [
+    (Story, context) => {
+      const { startTime, endTime, handleStartTimeChange, handleEndTimeChange } =
+        useTimeRangeDropdown();
+
+      return (
+        <Story
+          args={{
+            ...context.args,
+            startTime,
+            endTime,
+            handleStartTimeChange,
+            handleEndTimeChange,
+          }}
+        />
+      );
+    },
+  ],
+} satisfies Meta<typeof TimeRangeSelector>;
+
+export default meta;
+
+export const Default = {};

--- a/frontend/src/components/TimeRangeSelector/index.tsx
+++ b/frontend/src/components/TimeRangeSelector/index.tsx
@@ -1,0 +1,28 @@
+import Dropdown from '@components/_common/Dropdown';
+
+import type useTimeRangeDropdown from '@hooks/useTimeRangeDropdown/useTimeRangeDropdown';
+
+import { s_dropdownContainer } from './TimeRangeSelector.styles';
+
+export default function TimeRangeSelector({
+  startTime,
+  endTime,
+  handleStartTimeChange,
+  handleEndTimeChange,
+}: ReturnType<typeof useTimeRangeDropdown>) {
+  return (
+    <div css={s_dropdownContainer}>
+      <Dropdown
+        value={startTime.value}
+        onChange={(e) => handleStartTimeChange(e.target.value)}
+        options={startTime.options}
+      />
+      ~
+      <Dropdown
+        value={endTime.value}
+        onChange={(e) => handleEndTimeChange(e.target.value)}
+        options={endTime.options}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/_common/Dropdown/Dropdown.stories.tsx
+++ b/frontend/src/components/_common/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from 'storybook/internal/preview-api';
 
-import { INITIAL_END_TIME, INITIAL_START_TIME } from '@hooks/useTimeRangeDropdown/constants';
+import { INITIAL_START_TIME } from '@hooks/useTimeRangeDropdown/constants';
 import {
   generateEndTimeOptions,
   generateStartTimeOptions,
@@ -21,6 +22,22 @@ const meta = {
       description: '드롭다운 목록에 추가할 `value`와 `label`을 담고있는 객체 배열입니다.',
     },
   },
+  decorators: [
+    (Story, context) => {
+      const [{ time }, setArgState] = useArgs();
+
+      const handleChangeOptions = (time: string) => setArgState({ time: time });
+
+      return (
+        <Story
+          args={{
+            ...context.args,
+            onChange: () => handleChangeOptions(time),
+          }}
+        />
+      );
+    },
+  ],
 } satisfies Meta<typeof Dropdown>;
 
 export default meta;
@@ -56,7 +73,7 @@ export const Default: Story = {
 
 export const StartTime: Story = {
   args: {
-    options: generateStartTimeOptions(INITIAL_END_TIME),
+    options: generateStartTimeOptions(),
   },
 };
 

--- a/frontend/src/components/_common/Dropdown/index.tsx
+++ b/frontend/src/components/_common/Dropdown/index.tsx
@@ -11,9 +11,9 @@ interface DropdownProps extends SelectHTMLAttributes<HTMLSelectElement> {
   options: Option[];
 }
 
-export default function Dropdown({ options, ...props }: DropdownProps) {
+export default function Dropdown({ options, value, onChange }: DropdownProps) {
   return (
-    <select {...props} css={s_dropdown}>
+    <select value={value} onChange={onChange} css={s_dropdown}>
       {options.map(({ value, label }) => (
         <option key={value} value={value}>
           {label}

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
@@ -8,71 +8,51 @@ describe('useTimeRangeDropdown', () => {
   it(`초기 시작 시간(startTime)은 ${INITIAL_START_TIME}, 끝 시간(emdTime)은 ${INITIAL_END_TIME}으로 설정된다.`, () => {
     const { result } = renderHook(() => useTimeRangeDropdown());
 
-    expect(result.current.startTime).toBe(INITIAL_START_TIME);
-    expect(result.current.endTime).toBe(INITIAL_END_TIME);
+    expect(result.current.startTime.value).toBe(INITIAL_START_TIME);
+    expect(result.current.endTime.value).toBe(INITIAL_END_TIME);
   });
 
-  it('선택한 시작 시간(startTime)이 끝 시간(endTime)보다 느리다면 선택한 시간값으로 변경되지 않는다.', () => {
+  it('시작 시간(startTime)을 선택하면 끝 시간(endTime)은 시작 시간(startTime)의 1시간 이후로 설정된다.', () => {
     const CHANGE_TIME = '01:00';
+    const CHANGE_TIME_AFTER_HOUR = '02:00';
     const { result } = renderHook(() => useTimeRangeDropdown());
 
     act(() => {
-      result.current.onEndTimeChange('00:00');
+      result.current.handleStartTimeChange(CHANGE_TIME);
     });
 
-    act(() => {
-      result.current.onStartTimeChange(CHANGE_TIME);
-    });
-
-    expect(result.current.startTime).not.toBe(CHANGE_TIME);
-  });
-
-  it('선택한 시작 시간(startTime)이 끝 시간(endTime)보다 빠르다면 값이 선택한 시간값으로 변경된다.', () => {
-    const CHANGE_TIME = '01:00';
-    const { result } = renderHook(() => useTimeRangeDropdown());
-
-    act(() => {
-      result.current.onEndTimeChange('23:00');
-    });
-
-    act(() => {
-      result.current.onStartTimeChange(CHANGE_TIME);
-    });
-
-    expect(result.current.startTime).toBe(CHANGE_TIME);
+    expect(result.current.endTime.value).not.toBe(CHANGE_TIME_AFTER_HOUR);
   });
 
   it('선택한 끝 시간(endTime)이 시작 시간(startTime)보다 빠르다면 선택한 시간값으로 변경되지 않는다.', () => {
-    const CHANGE_TIME = '01:00';
+    const CHANGE_START_TIME = '04:00';
+    const CHANGE_END_TIME = '01:00';
     const { result } = renderHook(() => useTimeRangeDropdown());
 
     act(() => {
-      result.current.onEndTimeChange('15:00');
+      result.current.handleStartTimeChange(CHANGE_START_TIME);
     });
 
     act(() => {
-      result.current.onStartTimeChange('12:00');
+      result.current.handleEndTimeChange(CHANGE_END_TIME);
     });
 
-    act(() => {
-      result.current.onEndTimeChange(CHANGE_TIME);
-    });
-
-    expect(result.current.endTime).not.toBe(CHANGE_TIME);
+    expect(result.current.endTime.value).not.toBe(CHANGE_END_TIME);
   });
 
   it('선택한 끝 시간(endTime)이 시작 시간(startTime)보다 느리다면 선택한 시간값으로 변경된다.', () => {
-    const CHANGE_TIME = '12:00';
+    const CHANGE_START_TIME = '11:00';
+    const CHANGE_END_TIME = '12:00';
     const { result } = renderHook(() => useTimeRangeDropdown());
 
     act(() => {
-      result.current.onStartTimeChange('00:00');
+      result.current.handleStartTimeChange(CHANGE_START_TIME);
     });
 
     act(() => {
-      result.current.onEndTimeChange(CHANGE_TIME);
+      result.current.handleEndTimeChange(CHANGE_END_TIME);
     });
 
-    expect(result.current.endTime).toBe(CHANGE_TIME);
+    expect(result.current.endTime.value).toBe(CHANGE_END_TIME);
   });
 });

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.ts
@@ -1,20 +1,26 @@
 import { useState } from 'react';
 
 import { INITIAL_END_TIME, INITIAL_START_TIME } from './constants';
-import { isTimeSelectable } from './useTimeRangeDropdown.utils';
+import {
+  generateEndTimeOptions,
+  generateStartTimeOptions,
+  getTimeAfterOneHour,
+  isTimeSelectable,
+} from './useTimeRangeDropdown.utils';
 
 export default function useTimeRangeDropdown() {
   const [startTime, setStartTime] = useState(INITIAL_START_TIME);
   const [endTime, setEndTime] = useState(INITIAL_END_TIME);
 
-  // 시작 시간이 끝 시간보다 빠르다면 startTime이 변경되지 않도록 설정
+  // startTime의 onChange 핸들러 함수
+  // startTime을 선택하면 endTime은 (startTime + 1시간)으로 설정됩니다.
   const handleStartTimeChange = (time: string) => {
-    if (!isTimeSelectable(time, endTime)) return;
-
     setStartTime(time);
+    setEndTime(getTimeAfterOneHour(time));
   };
 
-  // 시작 시간이 끝 시간보다 빠르다면 startTime이 변경되지 않도록 설정
+  // endTime의 onChange 핸들러 함수
+  // startTime이 endTime보다 빠르다면 startTime이 변경되지 않습니다.
   const handleEndTimeChange = (time: string) => {
     if (!isTimeSelectable(startTime, time)) return;
 
@@ -22,9 +28,15 @@ export default function useTimeRangeDropdown() {
   };
 
   return {
-    startTime,
-    endTime,
-    onStartTimeChange: handleStartTimeChange,
-    onEndTimeChange: handleEndTimeChange,
+    startTime: {
+      value: startTime,
+      options: generateStartTimeOptions(),
+    },
+    endTime: {
+      value: endTime,
+      options: generateEndTimeOptions(startTime),
+    },
+    handleStartTimeChange,
+    handleEndTimeChange,
   } as const;
 }

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
@@ -10,12 +10,11 @@ function formatHours(hour: number) {
   return hour > 12 ? `오후 ${hour - 12}` : `오전 ${hour}`;
 }
 
-// 0시 ~ endTime까지의 시간만 선택 가능한 함수. 시작 시간 options에 사용
-export function generateStartTimeOptions(endTime: string) {
+// 0시 ~ 11:00까지의 시간만 선택 가능한 함수. 시작 시간 options에 사용
+export function generateStartTimeOptions() {
   const times: Option[] = [];
-  const endHours = Number(endTime.split(':')[0]);
 
-  for (let i = MINIMUM_TIME; i < endHours; i++) {
+  for (let i = MINIMUM_TIME; i < MAXIMUM_TIME; i++) {
     const label = formatHours(i);
 
     times.push({ value: `${String(i).padStart(2, '0')}:00`, label: label + ':00' });
@@ -31,6 +30,7 @@ export function generateEndTimeOptions(startTime: string) {
 
   for (let i = startHours + 1; i <= MAXIMUM_TIME; i++) {
     const label = formatHours(i).padStart(2, '0');
+
     times.push({ value: `${String(i).padStart(2, '0')}:00`, label: label + ':00' });
   }
 
@@ -46,4 +46,11 @@ export function isTimeSelectable(startTime: string, endTime: string) {
   if (endHours === startHours && endMinutes < startMinutes) return false;
 
   return true;
+}
+
+// 현재 시간에서 1시간 더한 시간을 반화해주는 함수(@낙타)
+export function getTimeAfterOneHour(time: string) {
+  const [currentHours, currentMinutes] = time.split(':').map(Number);
+
+  return currentHours + 1 + ':' + currentMinutes;
 }

--- a/frontend/src/pages/CreateMeetingPage/CreateMeetingPage.styles.ts
+++ b/frontend/src/pages/CreateMeetingPage/CreateMeetingPage.styles.ts
@@ -8,12 +8,6 @@ export const s_formContainer = css`
   gap: 2.4rem;
 `;
 
-export const s_dropdownContainer = css`
-  display: flex;
-  gap: 1.2rem;
-  justify-content: flex-start;
-`;
-
 export const s_confirmContainer = css`
   display: flex;
   align-items: center;

--- a/frontend/src/pages/CreateMeetingPage/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/index.tsx
@@ -1,26 +1,17 @@
 import { useState } from 'react';
 
+import TimeRangeSelector from '@components/TimeRangeSelector';
 import Calendar from '@components/_common/Calendar';
-import Dropdown from '@components/_common/Dropdown';
 import Field from '@components/_common/Field';
 import Input from '@components/_common/Input';
 
 import useInput from '@hooks/useInput/useInput';
 import { INITIAL_END_TIME, INITIAL_START_TIME } from '@hooks/useTimeRangeDropdown/constants';
 import useTimeRangeDropdown from '@hooks/useTimeRangeDropdown/useTimeRangeDropdown';
-import {
-  generateEndTimeOptions,
-  generateStartTimeOptions,
-} from '@hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils';
 
 import { usePostMeetingMutation } from '@stores/servers/meeting/mutation';
 
-import {
-  s_confirm,
-  s_confirmContainer,
-  s_dropdownContainer,
-  s_formContainer,
-} from './CreateMeetingPage.styles';
+import { s_confirm, s_confirmContainer, s_formContainer } from './CreateMeetingPage.styles';
 
 export default function CreateMeetingPage() {
   const { mutation: postMeetingMutation } = usePostMeetingMutation();
@@ -30,12 +21,7 @@ export default function CreateMeetingPage() {
   const { value: hostPassword, onValueChange: handleHostPasswordChange } = useInput('');
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
 
-  const {
-    startTime,
-    endTime,
-    onStartTimeChange: handleStartTimeChange,
-    onEndTimeChange: handleEndTimeChange,
-  } = useTimeRangeDropdown();
+  const { startTime, endTime, handleStartTimeChange, handleEndTimeChange } = useTimeRangeDropdown();
 
   const hasDate = (date: string) => selectedDates.includes(date);
 
@@ -51,9 +37,9 @@ export default function CreateMeetingPage() {
       hostPassword: hostPassword,
       meetingName: meetingName,
       availableMeetingDates: selectedDates,
-      meetingStartTime: startTime,
+      meetingStartTime: startTime.value,
       // 시간상 24시는 존재하지 않기 때문에 백엔드에서 오류가 발생. 따라서 오전 12:00으로 표현하지만, 서버에 00:00으로 전송(@낙타)
-      meetingEndTime: endTime === INITIAL_END_TIME ? INITIAL_START_TIME : endTime,
+      meetingEndTime: endTime.value === INITIAL_END_TIME ? INITIAL_START_TIME : endTime.value,
     });
   };
 
@@ -101,19 +87,12 @@ export default function CreateMeetingPage() {
         </Field>
 
         <Field id="약속시간범위선택" labelText="약속 시간 범위 선택">
-          <div css={s_dropdownContainer}>
-            <Dropdown
-              value={startTime}
-              onChange={(e) => handleStartTimeChange(e.target.value)}
-              options={generateStartTimeOptions(endTime)}
-            />
-            ~
-            <Dropdown
-              value={endTime}
-              onChange={(e) => handleEndTimeChange(e.target.value)}
-              options={generateEndTimeOptions(startTime)}
-            />
-          </div>
+          <TimeRangeSelector
+            startTime={startTime}
+            endTime={endTime}
+            handleStartTimeChange={handleStartTimeChange}
+            handleEndTimeChange={handleEndTimeChange}
+          />
         </Field>
         <div css={s_confirmContainer}>
           <button css={s_confirm} onClick={handleMeetingCreateButtonClick}>


### PR DESCRIPTION
## 관련 이슈

- resolves: #226 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

> 필독 : https://paper-mass-5ff.notion.site/Dropdown-b029bdc61111442bb2488836352466fa?pvs=4

- 시작 시간(startTime)을 선택하면 끝 시간(endTime)이 시작 시간(startTime) + 1시간으로 설정됩니다.
- storybook으로 테스트하기 위해 TimeRangeSelector 컴포넌트를 만들었습니다.


## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
