### PR TITLE
[BE] 운영환경 yml 추가

### DIFF
--- a/backend/src/main/resources/application-api-docs.yml
+++ b/backend/src/main/resources/application-api-docs.yml
@@ -1,0 +1,7 @@
+springdoc:
+  api-docs:
+    path: /api/v3/api-docs
+  swagger-ui:
+    path: /api/docs
+    tags-sorter: alpha
+    operations-sorter: alpha

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate.on-profile: prod
+    import:
+      - ${SECURITY_PATH:classpath:security}/datasource-prod.yml
+      - ${SECURITY_PATH:classpath:security}/jwt.yml
+      - ${SECURITY_PATH:classpath:security}/cors.yml
+      - ${SECURITY_PATH:classpath:security}/logback.yml
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,16 +3,9 @@ spring:
   profiles:
     active: local  # Default Active Profile
     group:
-      local: local  # Add 'local-remoteDB' to connect Remote MySQL
-      dev: dev
-
-springdoc:
-  api-docs:
-    path: /api/v3/api-docs
-  swagger-ui:
-    path: /api/docs
-    tags-sorter: alpha
-    operations-sorter: alpha
+      local: local, api-docs  # Add 'local-remoteDB' to connect Remote MySQL
+      dev: dev, api-docs
+      prod: prod
 
 server:
   port: 8080


### PR DESCRIPTION
## 관련 이슈

- resolves: #235 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

운영 환경이 추가되어 관련된 yml 파일과 몇가시 수정사항을 반영하였습니다. 

먼저, 서브모듈에 DB 관련 대외비를 추가하였습니다!
다음으로 운영 환경에 jpa 관련 동작을 명시하였습니다. 운영 환경에서 sql을 출력할 필요가 없어 관련 설정을 삭제하였습니다.

마지막으로 Swagger를 운영 환경 내 있을 필요가 없기에 관련 설정을 비활성화하였습니다!


## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

> 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요?

운영환경에서 swagger 관련 설정들을 비활성화하면서 `SwaggerConfig`이 운영 환경에서는 불필요한데요.
해당 Config 클래스를 `@Profile`을 이용하여 운영 환경 적용시 해당 빈들을 추가하지 않게끔 설정해야할지 고민입니다!
