### PR TITLE
[FE] 00:00~01:00 시간 범위로 약속을 생성할 경우, 02:00까지 렌더링되는 문제 해결

### DIFF
--- a/frontend/src/apis/meetings.ts
+++ b/frontend/src/apis/meetings.ts
@@ -1,8 +1,10 @@
+import type { MeetingBase, PostMeetingResult } from 'types/meeting';
+
 import { BASE_URL } from '@constants/api';
 
 import { fetchClient } from './_common/fetchClient';
 
-interface GetMeetingBaseResponse {
+interface MeetingBaseResponse {
   meetingName: string;
   firstTime: string;
   lastTime: string;
@@ -10,41 +12,12 @@ interface GetMeetingBaseResponse {
   hostName: string;
   availableDates: string[];
   attendeeNames: string[];
-}
-
-export interface MeetingBase {
-  meetingName: string;
-  firstTime: string;
-  lastTime: string;
-  isLocked: boolean;
-  hostName: string;
-  availableDates: string[];
-  attendeeNames: string[];
-}
-
-export interface MeetingRequest {
-  hostName: string;
-  hostPassword: string;
-  meetingName: string;
-  availableMeetingDates: string[];
-  meetingStartTime: string;
-  meetingEndTime: string;
-}
-
-interface PostMeetingResponse {
-  uuid: string;
-  hostName: string;
-}
-
-export interface MeetingInfo {
-  uuid: string;
-  userName: string;
 }
 
 export const getMeetingBase = async (uuid: string): Promise<MeetingBase> => {
   const path = `/${uuid}`;
 
-  const data = await fetchClient<GetMeetingBaseResponse>({
+  const data = await fetchClient<MeetingBaseResponse>({
     path,
     method: 'GET',
     errorMessage: '약속 정보를 조회하는 중 문제가 발생했어요 :(',
@@ -61,7 +34,21 @@ export const getMeetingBase = async (uuid: string): Promise<MeetingBase> => {
   };
 };
 
-export const postMeeting = async (request: MeetingRequest): Promise<MeetingInfo> => {
+interface PostMeetingRequest {
+  hostName: string;
+  hostPassword: string;
+  meetingName: string;
+  availableMeetingDates: string[];
+  meetingStartTime: string;
+  meetingEndTime: string;
+}
+
+interface PostMeetingResponse {
+  uuid: string;
+  hostName: string;
+}
+
+export const postMeeting = async (request: PostMeetingRequest): Promise<PostMeetingResult> => {
   const data = await fetchClient<PostMeetingResponse>({
     path: '',
     method: 'POST',
@@ -76,7 +63,7 @@ export const postMeeting = async (request: MeetingRequest): Promise<MeetingInfo>
   };
 };
 
-export const lockMeeting = async (uuid: string) => {
+export const lockMeeting = async (uuid: string): Promise<void> => {
   const response = await fetch(`${BASE_URL}/${uuid}/lock`, {
     method: 'PATCH',
     headers: {
@@ -90,7 +77,7 @@ export const lockMeeting = async (uuid: string) => {
   }
 };
 
-export const unlockMeeting = async (uuid: string) => {
+export const unlockMeeting = async (uuid: string): Promise<void> => {
   const response = await fetch(`${BASE_URL}/${uuid}/unlock`, {
     method: 'PATCH',
     headers: {

--- a/frontend/src/apis/meetings.ts
+++ b/frontend/src/apis/meetings.ts
@@ -63,7 +63,7 @@ export const postMeeting = async (request: PostMeetingRequest): Promise<PostMeet
   };
 };
 
-export const lockMeeting = async (uuid: string): Promise<void> => {
+export const lockMeeting = async (uuid: string) => {
   const response = await fetch(`${BASE_URL}/${uuid}/lock`, {
     method: 'PATCH',
     headers: {
@@ -77,7 +77,7 @@ export const lockMeeting = async (uuid: string): Promise<void> => {
   }
 };
 
-export const unlockMeeting = async (uuid: string): Promise<void> => {
+export const unlockMeeting = async (uuid: string) => {
   const response = await fetch(`${BASE_URL}/${uuid}/unlock`, {
     method: 'PATCH',
     headers: {

--- a/frontend/src/apis/schedules.ts
+++ b/frontend/src/apis/schedules.ts
@@ -1,40 +1,18 @@
+import type {
+  MeetingAllSchedules,
+  MeetingAllSchedulesItem,
+  MeetingSingeScheduleItem,
+  MeetingSingleSchedule,
+} from 'types/schedule';
+
 import { fetchClient } from './_common/fetchClient';
-
-interface SingleAttendeeTimeSlot {
-  date: string;
-  times: string[];
-}
-
-interface AllAttendeeTimeSlot {
-  date: string;
-  time: string;
-  attendeeNames: string[];
-}
-
-interface MeetingAllSchedulesResponse {
-  schedules: AllAttendeeTimeSlot[];
-}
-
-export interface MeetingAllSchedules {
-  schedules: AllAttendeeTimeSlot[];
-}
-
-interface MeetingSingleScheduleResponse {
-  attendeeName: string;
-  schedules: SingleAttendeeTimeSlot[];
-}
-
-export interface MeetingSingleSchedule {
-  attendeeName: string;
-  schedules: SingleAttendeeTimeSlot[];
-}
 
 export const postSchedule = async ({
   uuid,
   requestData,
 }: {
   uuid: string;
-  requestData: SingleAttendeeTimeSlot[];
+  requestData: MeetingSingeScheduleItem[];
 }) => {
   const path = `/${uuid}/schedules`;
 
@@ -57,6 +35,10 @@ export const createMeetingSchedulesRequestUrl = (uuid: string, attendeeName: str
   return `/${uuid}/schedules?${params.toString()}`;
 };
 
+interface MeetingAllSchedulesResponse {
+  schedules: MeetingAllSchedulesItem[];
+}
+
 const getMeetingAllSchedules = async (uuid: string): Promise<MeetingAllSchedules> => {
   const path = `/${uuid}/schedules`;
 
@@ -70,6 +52,11 @@ const getMeetingAllSchedules = async (uuid: string): Promise<MeetingAllSchedules
     schedules: data.schedules,
   };
 };
+
+interface MeetingSingleScheduleResponse {
+  attendeeName: string;
+  schedules: MeetingSingeScheduleItem[];
+}
 
 const getMeetingSingleSchedule = async ({
   attendeeName,

--- a/frontend/src/components/AttendeeTooltip/AttendeeTooltip.utils.ts
+++ b/frontend/src/components/AttendeeTooltip/AttendeeTooltip.utils.ts
@@ -1,4 +1,4 @@
-import type { MeetingAllSchedules } from '@apis/schedules';
+import type { MeetingAllSchedules } from 'types/schedule';
 
 export const findAttendeeNames = (
   allSchedules: MeetingAllSchedules,

--- a/frontend/src/components/AttendeeTooltip/index.tsx
+++ b/frontend/src/components/AttendeeTooltip/index.tsx
@@ -1,8 +1,7 @@
+import type { MeetingAllSchedules } from 'types/schedule';
 import type { TooltipPosition } from 'types/tooltip';
 
 import Tooltip from '@components/_common/Tooltip';
-
-import type { MeetingAllSchedules } from '@apis/schedules';
 
 import {
   s_attendeeText,

--- a/frontend/src/components/MeetingTimeCard/MeetingTimeCard.styles.ts
+++ b/frontend/src/components/MeetingTimeCard/MeetingTimeCard.styles.ts
@@ -8,7 +8,7 @@ export const s_baseContainer = css`
   padding: 0.8rem 1.2rem;
 
   opacity: 0.7;
-  background-color: ${theme.colors.timeTable.selected.light};
+  background-color: ${theme.colors.pink.light};
   border-radius: 0.8rem;
 `;
 

--- a/frontend/src/components/Schedules/AllSchedule.tsx
+++ b/frontend/src/components/Schedules/AllSchedule.tsx
@@ -1,8 +1,9 @@
+import type { MeetingDateTime } from 'types/meeting';
+import type { MeetingAllSchedules } from 'types/schedule';
+
 import AttendeeTooltip from '@components/AttendeeTooltip';
 
-import type { MeetingAllSchedules } from '@apis/schedules';
-
-import { generateScheduleMatrix } from './Picker/SchedulePicker.utils';
+import { generateAllScheduleTable } from './Picker/SchedulePicker.utils';
 import {
   s_container,
   s_scheduleTable,
@@ -14,24 +15,21 @@ import {
 } from './Schedules.styles';
 import { formatDate, formatTime, getTooltipPosition } from './Schedules.util';
 
-interface AllSchedulesProps {
-  firstTime: string;
-  lastTime: string;
-  availableDates: string[];
-  allSchedules: MeetingAllSchedules;
+interface AllSchedulesProps extends MeetingDateTime {
+  meetingAllSchedules: MeetingAllSchedules;
 }
 
 export default function AllSchedules({
   firstTime,
   lastTime,
   availableDates,
-  allSchedules,
+  meetingAllSchedules,
 }: AllSchedulesProps) {
-  const schedules = generateScheduleMatrix({
+  const schedules = generateAllScheduleTable({
     firstTime,
     lastTime,
     availableDates,
-    meetingSchedules: allSchedules,
+    meetingAllSchedules,
   });
 
   return (
@@ -64,7 +62,7 @@ export default function AllSchedules({
                 <td key={columnIndex} css={s_td(attendeeCount)}>
                   {attendeeCount > 0 && (
                     <AttendeeTooltip
-                      allSchedules={allSchedules}
+                      allSchedules={meetingAllSchedules}
                       availableDates={availableDates}
                       rowIndex={rowIndex}
                       columnIndex={columnIndex}

--- a/frontend/src/components/Schedules/Picker/SchedulePicker.utils.ts
+++ b/frontend/src/components/Schedules/Picker/SchedulePicker.utils.ts
@@ -73,7 +73,9 @@ export const generateAllScheduleTable = ({
     const rowIndex = timeSlotIndex[time];
     const colIndex = availableDates.indexOf(date);
 
-    allScheduleTable[rowIndex][colIndex] = attendeeNames.length;
+    if (rowIndex && colIndex !== -1) {
+      allScheduleTable[rowIndex][colIndex] = attendeeNames.length;
+    }
   });
 
   return allScheduleTable;
@@ -97,7 +99,9 @@ export const generateSingleScheduleTable = ({
     times.forEach((time) => {
       const rowIndex = timeSlotIndex[time];
 
-      singleScheduleTable[rowIndex][colIndex] = 1;
+      if (rowIndex) {
+        singleScheduleTable[rowIndex][colIndex] = 1;
+      }
     });
   });
 

--- a/frontend/src/components/Schedules/Picker/SchedulePicker.utils.ts
+++ b/frontend/src/components/Schedules/Picker/SchedulePicker.utils.ts
@@ -1,71 +1,107 @@
-import type { MeetingAllSchedules, MeetingSingleSchedule } from '@apis/schedules';
+import type { MeetingDateTime } from 'types/meeting';
+import type {
+  MeetingAllSchedules,
+  MeetingSingeScheduleItem,
+  MeetingSingleSchedule,
+} from 'types/schedule';
 
-const generateTimeSlots = (start: string, end: string) => {
-  const startHour = Number(start.split(':')[0]);
-  const endHour = Number(end.split(':')[0]);
-  const slots: string[] = [];
-
-  for (let i = startHour; i <= endHour; i++) {
-    slots.push(`${i.toString().padStart(2, '0')}:00`);
-  }
-
-  return slots;
-};
-
-interface GenerateScheduleMatrixProps {
-  firstTime: string;
-  lastTime: string;
-  availableDates: string[];
-  meetingSchedules: MeetingAllSchedules | MeetingSingleSchedule;
+interface GenerateAllScheduleTableArgs extends MeetingDateTime {
+  meetingAllSchedules: MeetingAllSchedules;
 }
 
-export const generateScheduleMatrix = ({
-  firstTime,
-  lastTime,
-  availableDates,
-  meetingSchedules,
-}: GenerateScheduleMatrixProps) => {
-  const timeSlots = generateTimeSlots(firstTime, lastTime);
+interface GenerateSingleScheduleTableArgs extends MeetingDateTime {
+  meetingSingleSchedule: MeetingSingleSchedule;
+}
+
+/**
+ * 주어진 시작 시간과 종료 시간 사이의 시간 슬롯을 "HH:00" 형식으로 생성합니다.
+ *
+ * @param {string} startTime - 시작 시간 ("HH:MM" 형식).
+ * @param {string} endTime - 종료 시간 ("HH:MM" 형식).
+ * @returns {string[]} "HH:00" 형식의 시간 슬롯 배열.
+ *
+ * @example 아래는 해당 함수를 사용할 때, 인자와 반환값에 대한 예시입니다 :)
+ * generateTimeSlots("09:00", "12:00");
+ * -> ["09:00", "10:00", "11:00"]
+ */
+const generateTimeSlots = (startTime: string, endTime: string): string[] => {
+  const startHour = Number(startTime.split(':')[0]);
+  const endHour = Number(endTime.split(':')[0]);
+
+  return Array.from(
+    { length: endHour - startHour },
+    (_, currentHour) => `${(startHour + currentHour).toString().padStart(2, '0')}:00`,
+  );
+};
+
+/**
+ * 주어진 시간 슬롯 배열에서 각 시간 슬롯에 해당하는 인덱스를 매핑한 객체를 생성합니다.
+ *
+ * @param {string[]} timeSlots - "HH:00" 형식의 시간 슬롯 배열.
+ * @returns {Record<string, number>} 각 시간 슬롯을 키로, 해당 슬롯의 인덱스를 값으로 가지는 객체.
+ *
+ * @example
+ * const timeSlots = ["09:00", "10:00", "11:00"];
+ * const timeSlotIndex = generateTimeSlotIndex(timeSlots);
+ * -> { "09:00": 0, "10:00": 1, "11:00": 2 }
+ */
+const generateTimeSlotIndex = (timeSlots: string[]): Record<string, number> => {
   const timeSlotIndex = timeSlots.reduce(
-    (acc, slot, idx) => {
-      acc[slot] = idx;
-      return acc;
+    (accTimeSlotIndex, currentTimeSlot, index) => {
+      accTimeSlotIndex[currentTimeSlot] = index;
+      return accTimeSlotIndex;
     },
     {} as Record<string, number>,
   );
 
-  const scheduleMatrix: number[][] = Array.from({ length: timeSlots.length }, (): number[] =>
+  return timeSlotIndex;
+};
+
+export const generateAllScheduleTable = ({
+  firstTime,
+  lastTime,
+  availableDates,
+  meetingAllSchedules,
+}: GenerateAllScheduleTableArgs) => {
+  const timeSlots = generateTimeSlots(firstTime, lastTime);
+  const timeSlotIndex = generateTimeSlotIndex(timeSlots);
+  const allScheduleTable: number[][] = Array.from({ length: timeSlots.length }, (): number[] =>
     Array(availableDates.length).fill(0),
   );
 
-  if (meetingSchedules) {
-    if ('attendeeName' in meetingSchedules) {
-      meetingSchedules.schedules.forEach(({ date, times }) => {
-        const colIndex = availableDates.indexOf(date);
+  meetingAllSchedules.schedules.forEach(({ date, time, attendeeNames }) => {
+    const rowIndex = timeSlotIndex[time];
+    const colIndex = availableDates.indexOf(date);
 
-        if (colIndex !== -1) {
-          times.forEach((time) => {
-            const rowIndex = timeSlotIndex[time];
+    allScheduleTable[rowIndex][colIndex] = attendeeNames.length;
+  });
 
-            if (rowIndex !== undefined) {
-              scheduleMatrix[rowIndex][colIndex] = 1;
-            }
-          });
-        }
-      });
-    } else {
-      meetingSchedules.schedules.forEach(({ date, time, attendeeNames }) => {
-        const rowIndex = timeSlotIndex[time];
-        const colIndex = availableDates.indexOf(date);
+  return allScheduleTable;
+};
 
-        if (rowIndex !== undefined && colIndex !== -1) {
-          scheduleMatrix[rowIndex][colIndex] = attendeeNames.length;
-        }
-      });
-    }
-  }
+export const generateSingleScheduleTable = ({
+  firstTime,
+  lastTime,
+  availableDates,
+  meetingSingleSchedule,
+}: GenerateSingleScheduleTableArgs) => {
+  const timeSlots = generateTimeSlots(firstTime, lastTime);
+  const timeSlotIndex = generateTimeSlotIndex(timeSlots);
+  const singleScheduleTable: number[][] = Array.from({ length: timeSlots.length }, (): number[] =>
+    Array(availableDates.length).fill(0),
+  );
 
-  return scheduleMatrix;
+  meetingSingleSchedule.schedules.forEach(({ date, times }) => {
+    const colIndex = availableDates.indexOf(date);
+
+    times.forEach((time) => {
+      const rowIndex = timeSlotIndex[time];
+
+      singleScheduleTable[rowIndex][colIndex] = 1;
+    });
+  });
+
+  return singleScheduleTable;
 };
 
 export const convertToSchedule = (
@@ -73,9 +109,8 @@ export const convertToSchedule = (
   availableDates: string[],
   startTime: string,
   endTime: string,
-) => {
+): MeetingSingeScheduleItem[] => {
   const timeSlots = generateTimeSlots(startTime, endTime);
-
   const schedules = availableDates.map((date, colIndex) => {
     const times: string[] = [];
 

--- a/frontend/src/components/Schedules/Picker/SchedulePickerContainer.tsx
+++ b/frontend/src/components/Schedules/Picker/SchedulePickerContainer.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
+import type { MeetingDateTime } from 'types/meeting';
 
 import { getMeetingMySchedule } from '@apis/schedules';
 
@@ -7,17 +8,11 @@ import { QUERY_KEY } from '@constants/queryKeys';
 
 import SchedulePicker from '.';
 
-interface SchedulePickerContainerProps {
-  firstTime: string;
-  lastTime: string;
-  availableDates: string[];
-}
-
 export default function SchedulePickerContainer({
   firstTime,
   lastTime,
   availableDates,
-}: SchedulePickerContainerProps) {
+}: MeetingDateTime) {
   const params = useParams<{ uuid: string }>();
   const uuid = params.uuid!;
   const { data: meetingSchedules } = useQuery({
@@ -33,7 +28,7 @@ export default function SchedulePickerContainer({
         firstTime={firstTime}
         lastTime={lastTime}
         availableDates={availableDates}
-        meetingSchedules={meetingSchedules}
+        meetingSingleSchedule={meetingSchedules}
       />
     )
   );

--- a/frontend/src/components/Schedules/Picker/index.tsx
+++ b/frontend/src/components/Schedules/Picker/index.tsx
@@ -2,14 +2,14 @@ import { css } from '@emotion/react';
 import { useContext } from 'react';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import type { MeetingDateTime } from 'types/meeting';
+import type { MeetingSingleSchedule } from 'types/schedule';
 
 import { TimePickerUpdateStateContext } from '@contexts/TimePickerUpdateStateProvider';
 
 import { Button } from '@components/_common/Buttons/Button';
 
 import usePagedTimePick from '@hooks/usePagedTimePick/usePagedTimePick';
-
-import type { MeetingSingleSchedule } from '@apis/schedules';
 
 import { usePostScheduleMutation } from '@stores/servers/schedule/mutations';
 
@@ -26,31 +26,28 @@ import {
   s_timeText,
 } from '../Schedules.styles';
 import { formatDate, formatTime } from '../Schedules.util';
-import { convertToSchedule, generateScheduleMatrix } from './SchedulePicker.utils';
+import { convertToSchedule, generateSingleScheduleTable } from './SchedulePicker.utils';
 
-interface SchedulePickerProps {
-  firstTime: string;
-  lastTime: string;
-  availableDates: string[];
-  meetingSchedules: MeetingSingleSchedule;
+interface SchedulePickerProps extends MeetingDateTime {
+  meetingSingleSchedule: MeetingSingleSchedule;
 }
 
 export default function SchedulePicker({
   firstTime,
   lastTime,
   availableDates,
-  meetingSchedules,
+  meetingSingleSchedule,
 }: SchedulePickerProps) {
   const params = useParams<{ uuid: string }>();
   const uuid = params.uuid!;
 
   const { handleToggleIsTimePickerUpdate } = useContext(TimePickerUpdateStateContext);
 
-  const schedules = generateScheduleMatrix({
+  const schedules = generateSingleScheduleTable({
     firstTime,
     lastTime,
     availableDates,
-    meetingSchedules,
+    meetingSingleSchedule,
   });
 
   const {

--- a/frontend/src/components/Schedules/SchedulesViewer.tsx
+++ b/frontend/src/components/Schedules/SchedulesViewer.tsx
@@ -2,6 +2,8 @@ import { css } from '@emotion/react';
 import { useQuery } from '@tanstack/react-query';
 import React, { useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import type { MeetingDateTime } from 'types/meeting';
+import type { MeetingAllSchedules, MeetingSingleSchedule } from 'types/schedule';
 
 import { AuthContext } from '@contexts/AuthProvider';
 import { TimePickerUpdateStateContext } from '@contexts/TimePickerUpdateStateProvider';
@@ -13,7 +15,6 @@ import {
 
 import useSelectSchedule from '@hooks/useSelectSchedule/useSelectSchedule';
 
-import type { MeetingAllSchedules, MeetingSingleSchedule } from '@apis/schedules';
 import { handleGetMeetingSchedules } from '@apis/schedules';
 
 import { QUERY_KEY } from '@constants/queryKeys';
@@ -26,11 +27,8 @@ import {
 } from './Schedules.styles';
 import SingleSchedule from './SingleSchedule';
 
-interface SchedulesViewerProps {
+interface SchedulesViewerProps extends MeetingDateTime {
   isLocked: boolean;
-  firstTime: string;
-  lastTime: string;
-  availableDates: string[];
   meetingAttendees: string[];
 }
 
@@ -115,21 +113,23 @@ export default function SchedulesViewer({
             </button>
           </div>
         )}
-        {selectedAttendee === '' ? (
-          <AllSchedules
-            firstTime={firstTime}
-            lastTime={lastTime}
-            availableDates={currentDates}
-            allSchedules={meetingSchedules as MeetingAllSchedules}
-          />
-        ) : (
-          <SingleSchedule
-            firstTime={firstTime}
-            lastTime={lastTime}
-            availableDates={currentDates}
-            singleSchedule={meetingSchedules as MeetingSingleSchedule}
-          />
-        )}
+        {selectedAttendee === ''
+          ? meetingSchedules && (
+              <AllSchedules
+                firstTime={firstTime}
+                lastTime={lastTime}
+                availableDates={currentDates}
+                meetingAllSchedules={meetingSchedules as MeetingAllSchedules}
+              />
+            )
+          : meetingSchedules && (
+              <SingleSchedule
+                firstTime={firstTime}
+                lastTime={lastTime}
+                availableDates={currentDates}
+                meetingSingleSchedule={meetingSchedules as MeetingSingleSchedule}
+              />
+            )}
       </section>
       <div css={s_buttonContainer}>
         <button disabled={isLocked} onClick={handleScheduleUpdate}>

--- a/frontend/src/components/Schedules/SingleSchedule.tsx
+++ b/frontend/src/components/Schedules/SingleSchedule.tsx
@@ -1,6 +1,7 @@
-import type { MeetingSingleSchedule } from '@apis/schedules';
+import type { MeetingDateTime } from 'types/meeting';
+import type { MeetingSingleSchedule } from 'types/schedule';
 
-import { generateScheduleMatrix } from './Picker/SchedulePicker.utils';
+import { generateSingleScheduleTable } from './Picker/SchedulePicker.utils';
 import {
   s_container,
   s_scheduleTable,
@@ -12,24 +13,21 @@ import {
 } from './Schedules.styles';
 import { formatDate, formatTime } from './Schedules.util';
 
-interface SingleScheduleProps {
-  firstTime: string;
-  lastTime: string;
-  availableDates: string[];
-  singleSchedule: MeetingSingleSchedule;
+interface SingleScheduleProps extends MeetingDateTime {
+  meetingSingleSchedule: MeetingSingleSchedule;
 }
 
 export default function SingleSchedule({
   firstTime,
   lastTime,
   availableDates,
-  singleSchedule,
+  meetingSingleSchedule,
 }: SingleScheduleProps) {
-  const schedules = generateScheduleMatrix({
+  const schedules = generateSingleScheduleTable({
     firstTime,
     lastTime,
     availableDates,
-    meetingSchedules: singleSchedule,
+    meetingSingleSchedule,
   });
 
   return (

--- a/frontend/src/layouts/GlobalLayout.styles.ts
+++ b/frontend/src/layouts/GlobalLayout.styles.ts
@@ -5,8 +5,9 @@ export const s_globalContainer = css`
   flex-direction: column;
   gap: 2.4rem;
 
-  min-width: 39.3rem;
-  max-width: 60rem;
+  min-width: 32rem;
+  max-width: 43rem;
+  width: 100vw;
   height: 100%;
 
   background-color: #fff;

--- a/frontend/src/stores/servers/meeting/mutation.ts
+++ b/frontend/src/stores/servers/meeting/mutation.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import type { PostMeetingResult } from 'types/meeting';
 
 import { AuthContext } from '@contexts/AuthProvider';
 
-import type { MeetingInfo } from '@apis/meetings';
 import { lockMeeting, postMeeting, unlockMeeting } from '@apis/meetings';
 
 import { QUERY_KEY } from '@constants/queryKeys';
@@ -15,7 +15,7 @@ export const usePostMeetingMutation = () => {
   const authContext = useContext(AuthContext);
   const { setIsLoggedIn, setUserName } = authContext.actions;
 
-  const [meetingInfo, setMeetingInfo] = useState<MeetingInfo>({
+  const [meetingInfo, setMeetingInfo] = useState<PostMeetingResult>({
     uuid: '',
     userName: '',
   });

--- a/frontend/src/types/meeting.ts
+++ b/frontend/src/types/meeting.ts
@@ -1,0 +1,17 @@
+export interface MeetingDateTime {
+  firstTime: string;
+  lastTime: string;
+  availableDates: string[];
+}
+
+export interface MeetingBase extends MeetingDateTime {
+  meetingName: string;
+  hostName: string;
+  attendeeNames: string[];
+  isLocked: boolean;
+}
+
+export interface PostMeetingResult {
+  uuid: string;
+  userName: string;
+}

--- a/frontend/src/types/schedule.ts
+++ b/frontend/src/types/schedule.ts
@@ -1,0 +1,19 @@
+export interface MeetingAllSchedulesItem {
+  date: string;
+  time: string;
+  attendeeNames: string[];
+}
+
+export interface MeetingAllSchedules {
+  schedules: MeetingAllSchedulesItem[];
+}
+
+export interface MeetingSingeScheduleItem {
+  date: string;
+  times: string[];
+}
+
+export interface MeetingSingleSchedule {
+  attendeeName: string;
+  schedules: MeetingSingeScheduleItem[];
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #244 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

### 버그 해결

- 00:00~01:00 시간 범위로 약속을 생성할 경우, 02:00까지 렌더링되는 문제 해결했습니다.

```
{
  "data": {
    "meetingName": "momo",
    "firstTime": "00:00",
    "lastTime": "01:00",
    "isLocked": false,
    "availableDates": ["2024-07-24", "2024-07-25", "2024-07-26", "2024-07-27"],
    "attendeeNames": ["낙타", "해리", "빙봉"]
  }
}
```
다음과 같이 00:00-01:00으로 약속을 생성하는 경우에는 

<img width="391" alt="image" src="https://github.com/user-attachments/assets/9b387817-ce67-4c74-ad0b-08a3a02c8627">

01:00까지만 렌더링 되도록 문제를 해결했습니다. 

```ts
const generateTimeSlots = (start: string, end: string) => {
  const startHour = Number(start.split(':')[0]);
  const endHour = Number(end.split(':')[0]);
  const slots: string[] = [];

  for (let i = startHour; i <= endHour; i++) {
    slots.push(`${i.toString().padStart(2, '0')}:00`);
  }

  return slots;
};
```
알고 보니까, endHour까지 포함해서 약속을 생성했기 때문에 생기는 문제였어요 :)

### 타입 수정

유틸 함수와 컴포넌트에서 반복해서 사용되는 타입들이 @api 폴더에서 관리되고 있는데 여기저기서 사용되는 타입들은 @types 폴더에서 관리되는게 맞다고 판단해서 타입 정의를 옮겼습니다. 옮기는 김에 타입명도 더 의미있게 수정했습니다. 

타입명을 의미있게 수정하면서 했던 고민들과 의사 결정 과정은 [여기](https://paper-mass-5ff.notion.site/e8a400910f1d43d4a75c79a4733ca3a9)에서 확인할 수 있어요!

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
