### PR TITLE
[FE] 입력 필드 버그 수정

### DIFF
--- a/frontend/src/components/PasswordInput/index.tsx
+++ b/frontend/src/components/PasswordInput/index.tsx
@@ -25,6 +25,7 @@ export default function PasswordInput({ value, onChange, placeholder = '' }: Inp
         onChange={onChange}
         placeholder={placeholder}
         aria-label="비밀번호 입력"
+        autoComplete="new-password"
       />
       <Button
         variant="transparent"

--- a/frontend/src/components/PasswordInput/index.tsx
+++ b/frontend/src/components/PasswordInput/index.tsx
@@ -33,7 +33,11 @@ export default function PasswordInput({ value, onChange, placeholder = '' }: Inp
         onClick={handlePasswordVisibilityToggle}
         aria-label={isPasswordShow ? '비밀번호 숨기기' : '비밀번호 보이기'}
       >
-        {isPasswordShow ? <PasswordHide /> : <PasswordShow />}
+        {isPasswordShow ? (
+          <PasswordHide width="20" height="20" />
+        ) : (
+          <PasswordShow width="20" height="20" />
+        )}
       </Button>
     </div>
   );

--- a/frontend/src/components/_common/Field/Field.styles.ts
+++ b/frontend/src/components/_common/Field/Field.styles.ts
@@ -28,5 +28,5 @@ export const s_errorMessage = css`
   display: flex;
   align-items: center;
   ${theme.typography.captionMedium}
-  color: ${PRIMITIVE_COLORS.red};
+  color: ${PRIMITIVE_COLORS.red[300]};
 `;

--- a/frontend/src/components/_common/Input/Input.styles.ts
+++ b/frontend/src/components/_common/Input/Input.styles.ts
@@ -7,6 +7,7 @@ const baseInputStyle = css`
   height: 4.4rem;
   padding: 0.8rem;
   outline-color: ${theme.colors.primary};
+  ${theme.typography.bodyLight}
 `;
 
 export const s_input = {

--- a/frontend/src/pages/CreateMeetingPage/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/index.tsx
@@ -95,7 +95,12 @@ export default function CreateMeetingPage() {
         <Field>
           <Field.Label id="약속이름" labelText="약속 이름" />
           <Field.Description description={FIELD_DESCRIPTIONS.meetingName} />
-          <Input id="약속이름" value={meetingName} onChange={handleMeetingNameChange} />
+          <Input
+            id="약속이름"
+            value={meetingName}
+            onChange={handleMeetingNameChange}
+            autoComplete="off"
+          />
           <Field.ErrorMessage errorMessage={meetingNameErrorMessage} />
         </Field>
 


### PR DESCRIPTION
## 관련 이슈
- resolves: #263 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->
<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
### iOS/사파리에서 '비밀번호 숨기기/보이기' SVG 아이콘이 보이지 않는 문제 해결
SVG 컴포넌트에 width와 height 값이 설정되지 않아 발생한 문제입니다. → width와 height를 각각 20으로 설정하였습니다.

### 입력 오류 메시지가 검은색으로 표시되는 문제 해결
`PRIMITIVE_COLORS.red`가 기존의 단일 값(`red: '#ff0000'`)에서
다중 값(`red: { 100: '#F58E8E', 200: '#F26969', 300: '#EF4545', 400: '#EB1E1E', 500: '#CE1212' }`)으로 변경되었습니다.

이에 따라 기존 코드에서 `PRIMITIVE_COLORS.red`를 참조하면 `undefined`가 반환되어 검은색으로 표시되는 문제가 발생했습니다. → 오류 메시지 색상을 빨간색(`PRIMITIVE_COLORS.red[300]`)으로 수정하였습니다.

### iOS/사파리에서 입력 필드 포커스 시 확대 방지
iOS/사파리에서는 `input` 및 `textarea` 요소의 `font-size`가 16px 미만일 경우 포커스 시 자동으로 화면이 확대되는 특성이 있습니다.
이를 방지하기 위해 `input` 스타일에 16px 이상의 `bodyLight` 타이포그래피를 적용하였습니다.

### input 자동완성 막기
약속 이름과 비밀번호 입력 필드의 자동완성을 방지하였습니다.
약속 이름 필드에는 `autoComplete="off"` 속성을 적용하였으며, 비밀번호 필드(input type="password")의 경우 `autoComplete="off"`가 동작하지 않기 때문에 `autoComplete="new-password"` 속성을 적용하였습니다.

닉네임 필드의 경우, 사용자들이 자주 사용하는 닉네임을 자동완성으로 편리하게 입력할 수 있도록 자동완성을 허용하였습니다.

## 특이 사항
<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)
<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->
<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->
<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
