### PR TITLE
[BE] JPA의 saveAll, deleteAll를 bulk query로 개선

### DIFF
--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDate.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDate.java
@@ -55,4 +55,8 @@ public class AvailableDate extends BaseEntity {
     public boolean isEqual(LocalDate other) {
         return date.isEqual(other);
     }
+
+    public Long meetingId() {
+        return meeting.getId();
+    }
 }

--- a/backend/src/main/java/kr/momo/domain/availabledate/AvailableDateBatchRepository.java
+++ b/backend/src/main/java/kr/momo/domain/availabledate/AvailableDateBatchRepository.java
@@ -1,0 +1,47 @@
+package kr.momo.domain.availabledate;
+
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class AvailableDateBatchRepository {
+
+    private static final int BATCH_SIZE = 30;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void batchInsert(Collection<AvailableDate> availableDates) {
+        String sql = """
+                INSERT INTO available_date (date, meeting_id, created_at, modified_at)
+                VALUES (?, ?, ?, ?);
+                """;
+
+        executeBatchUpdate(availableDates, sql);
+    }
+
+    private void executeBatchUpdate(Collection<AvailableDate> availableDates, String sql) {
+        LocalDateTime now = LocalDateTime.now();
+        Timestamp timestamp = Timestamp.valueOf(now);
+
+        jdbcTemplate.batchUpdate(sql, availableDates, BATCH_SIZE, createPreparedStatementSetter(timestamp));
+    }
+
+    private ParameterizedPreparedStatementSetter<AvailableDate> createPreparedStatementSetter(Timestamp timestamp) {
+        return (PreparedStatement ps, AvailableDate availableDate) -> {
+            ps.setDate(1, Date.valueOf(availableDate.getDate()));
+            ps.setLong(2, availableDate.meetingId());
+            ps.setTimestamp(3, timestamp);
+            ps.setTimestamp(4, timestamp);
+        };
+    }
+}

--- a/backend/src/main/java/kr/momo/domain/schedule/Schedule.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/Schedule.java
@@ -64,7 +64,15 @@ public class Schedule extends BaseEntity {
         return timeslot.startTime();
     }
 
+    public Long attendeeId() {
+        return attendee.getId();
+    }
+
     public String attendeeName() {
         return attendee.name();
+    }
+
+    public Long availableDateId() {
+        return availableDate.getId();
     }
 }

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
@@ -1,14 +1,12 @@
 package kr.momo.domain.schedule;
 
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.List;
-import lombok.NonNull;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,31 +14,34 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleBatchRepository {
 
+    private static final int BATCH_SIZE = 1000;
+
     private final JdbcTemplate jdbcTemplate;
 
     @Transactional
-    public void batchInsert(List<Schedule> schedules) {
+    public void batchInsert(Collection<Schedule> schedules) {
         String sql = """
-                    INSERT INTO schedule (attendee_id, available_date_id, timeslot, created_at, modified_at)
-                    VALUES (?, ?, ?, ?, ?);
+                INSERT INTO schedule (attendee_id, available_date_id, timeslot, created_at, modified_at)
+                VALUES (?, ?, ?, ?, ?);
                 """;
 
-        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
-            @Override
-            public void setValues(@NonNull PreparedStatement ps, int i) throws SQLException {
-                Schedule schedule = schedules.get(i);
-                LocalDateTime now = LocalDateTime.now();
-                ps.setLong(1, schedule.attendeeId());
-                ps.setLong(2, schedule.availableDateId());
-                ps.setString(3, schedule.getTimeslot().toString());
-                ps.setTimestamp(4, Timestamp.valueOf(now));
-                ps.setTimestamp(5, Timestamp.valueOf(now));
-            }
+        executeBatchUpdate(schedules, sql);
+    }
 
-            @Override
-            public int getBatchSize() {
-                return schedules.size();
-            }
-        });
+    private void executeBatchUpdate(Collection<Schedule> schedules, String sql) {
+        LocalDateTime now = LocalDateTime.now();
+        Timestamp timestamp = Timestamp.valueOf(now);
+
+        jdbcTemplate.batchUpdate(sql, schedules, BATCH_SIZE, createPreparedStatementSetter(timestamp));
+    }
+
+    private ParameterizedPreparedStatementSetter<Schedule> createPreparedStatementSetter(Timestamp timestamp) {
+        return (PreparedStatement ps, Schedule schedule) -> {
+            ps.setLong(1, schedule.attendeeId());
+            ps.setLong(2, schedule.availableDateId());
+            ps.setString(3, schedule.getTimeslot().toString());
+            ps.setTimestamp(4, timestamp);
+            ps.setTimestamp(5, timestamp);
+        };
     }
 }

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
@@ -16,8 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleBatchRepository {
 
-    private static final int BATCH_SIZE = 1000;
-
     private final JdbcTemplate jdbcTemplate;
 
     @Transactional
@@ -41,7 +39,7 @@ public class ScheduleBatchRepository {
 
             @Override
             public int getBatchSize() {
-                return BATCH_SIZE;
+                return schedules.size();
             }
         });
     }

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleBatchRepository {
 
-    private static final int BATCH_SIZE = 1000;
+    private static final int BATCH_SIZE = 500;
 
     private final JdbcTemplate jdbcTemplate;
 

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
@@ -1,0 +1,47 @@
+package kr.momo.domain.schedule;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class ScheduleBatchRepository {
+
+    private static final int BATCH_SIZE = 1000;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void batchInsert(List<Schedule> schedules) {
+        String sql = """
+                    INSERT INTO schedule (attendee_id, available_date_id, timeslot, created_at, modified_at)
+                    VALUES (?, ?, ?, ?, ?);
+                """;
+
+        jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                Schedule schedule = schedules.get(i);
+                LocalDateTime now = LocalDateTime.now();
+                ps.setLong(1, schedule.attendeeId());
+                ps.setLong(2, schedule.availableDateId());
+                ps.setString(3, schedule.getTimeslot().toString());
+                ps.setTimestamp(4, Timestamp.valueOf(now));
+                ps.setTimestamp(5, Timestamp.valueOf(now));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return BATCH_SIZE;
+            }
+        });
+    }
+}

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleBatchRepository.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -28,7 +29,7 @@ public class ScheduleBatchRepository {
 
         jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
             @Override
-            public void setValues(PreparedStatement ps, int i) throws SQLException {
+            public void setValues(@NonNull PreparedStatement ps, int i) throws SQLException {
                 Schedule schedule = schedules.get(i);
                 LocalDateTime now = LocalDateTime.now();
                 ps.setLong(1, schedule.attendeeId());

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
@@ -16,6 +17,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findAllByAttendeeIn(List<Attendee> attendees);
 
     @Modifying
+    @Transactional
     @Query("DELETE FROM Schedule s WHERE s.attendee = :attendee")
     void deleteByAttendee(Attendee attendee);
 }

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import kr.momo.domain.attendee.Attendee;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
@@ -13,5 +15,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @EntityGraph(attributePaths = {"availableDate"})
     List<Schedule> findAllByAttendeeIn(List<Attendee> attendees);
 
-    void deleteAllByAttendee(Attendee attendee);
+    @Modifying
+    @Query("DELETE FROM Schedule s WHERE s.attendee = :attendee")
+    void deleteByAttendee(Attendee attendee);
 }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.attendee.AttendeeRepository;
 import kr.momo.domain.attendee.Role;
+import kr.momo.domain.availabledate.AvailableDateBatchRepository;
 import kr.momo.domain.availabledate.AvailableDateRepository;
 import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
@@ -33,6 +34,7 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final AvailableDateRepository availableDateRepository;
     private final AttendeeRepository attendeeRepository;
+    private final AvailableDateBatchRepository availableDateBatchRepository;
 
     @Transactional
     public MeetingCreateResponse create(MeetingCreateRequest request) {
@@ -40,7 +42,7 @@ public class MeetingService {
         AvailableDates meetingDates = new AvailableDates(request.toAvailableMeetingDates(), meeting);
 
         validateNotPast(meetingDates);
-        availableDateRepository.saveAll(meetingDates.getAvailableDates());
+        availableDateBatchRepository.batchInsert(meetingDates.getAvailableDates());
         Attendee attendee = saveHostAttendee(meeting, request.hostName(), request.hostPassword());
         String token = jwtManager.generate(attendee.getId());
 

--- a/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
@@ -24,6 +24,7 @@ import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
 import kr.momo.domain.meeting.MeetingRepository;
 import kr.momo.domain.schedule.Schedule;
+import kr.momo.domain.schedule.ScheduleBatchRepository;
 import kr.momo.domain.schedule.ScheduleRepository;
 import kr.momo.domain.timeslot.Timeslot;
 import kr.momo.exception.MomoException;
@@ -47,6 +48,7 @@ public class ScheduleService {
     private final AttendeeRepository attendeeRepository;
     private final ScheduleRepository scheduleRepository;
     private final AvailableDateRepository availableDateRepository;
+    private final ScheduleBatchRepository scheduleBatchRepository;
 
     @Transactional
     public void create(String uuid, long attendeeId, ScheduleCreateRequest request) {
@@ -57,9 +59,9 @@ public class ScheduleService {
         Attendee attendee = attendeeRepository.findByIdAndMeeting(attendeeId, meeting)
                 .orElseThrow(() -> new MomoException(AttendeeErrorCode.INVALID_ATTENDEE));
 
-        scheduleRepository.deleteAllByAttendee(attendee);
+        scheduleRepository.deleteByAttendee(attendee);
         List<Schedule> schedules = createSchedules(request, meeting, attendee);
-        scheduleRepository.saveAll(schedules);
+        scheduleBatchRepository.batchInsert(schedules);
     }
 
     private void validateMeetingUnLocked(Meeting meeting) {

--- a/backend/src/test/java/kr/momo/domain/availabledate/AvailableDateBatchRepositoryTest.java
+++ b/backend/src/test/java/kr/momo/domain/availabledate/AvailableDateBatchRepositoryTest.java
@@ -1,0 +1,51 @@
+package kr.momo.domain.availabledate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import kr.momo.domain.meeting.Meeting;
+import kr.momo.domain.meeting.MeetingRepository;
+import kr.momo.fixture.AvailableDateFixture;
+import kr.momo.fixture.MeetingFixture;
+import kr.momo.support.IsolateDatabase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+@IsolateDatabase
+class AvailableDateBatchRepositoryTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private AvailableDateBatchRepository availableDateBatchRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    private Meeting meeting;
+
+    @BeforeEach
+    void setUp() {
+        meeting = meetingRepository.save(MeetingFixture.COFFEE.create());
+    }
+
+    @DisplayName("AvailableDate 리스트를 Batch Insert 한다.")
+    @Test
+    void batchInsertTest() {
+        List<AvailableDate> availableDate = List.of(
+                AvailableDateFixture.TODAY.create(meeting),
+                AvailableDateFixture.TOMORROW.create(meeting)
+        );
+
+        availableDateBatchRepository.batchInsert(availableDate);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM available_date", Integer.class);
+        assertThat(count).isEqualTo(availableDate.size());
+    }
+}

--- a/backend/src/test/java/kr/momo/domain/schedule/ScheduleBatchRepositoryTest.java
+++ b/backend/src/test/java/kr/momo/domain/schedule/ScheduleBatchRepositoryTest.java
@@ -1,0 +1,67 @@
+package kr.momo.domain.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import kr.momo.domain.attendee.Attendee;
+import kr.momo.domain.attendee.AttendeeRepository;
+import kr.momo.domain.availabledate.AvailableDate;
+import kr.momo.domain.availabledate.AvailableDateRepository;
+import kr.momo.domain.meeting.Meeting;
+import kr.momo.domain.meeting.MeetingRepository;
+import kr.momo.domain.timeslot.Timeslot;
+import kr.momo.fixture.AttendeeFixture;
+import kr.momo.fixture.AvailableDateFixture;
+import kr.momo.fixture.MeetingFixture;
+import kr.momo.support.IsolateDatabase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+@IsolateDatabase
+class ScheduleBatchRepositoryTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ScheduleBatchRepository scheduleBatchRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private AttendeeRepository attendeeRepository;
+
+    @Autowired
+    private AvailableDateRepository availableDateRepository;
+
+    private Attendee attendee;
+    private AvailableDate availableDate;
+
+    @BeforeEach
+    void setUp() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.COFFEE.create());
+        attendee = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
+        availableDate = availableDateRepository.save(AvailableDateFixture.TODAY.create(meeting));
+    }
+
+    @DisplayName("Schedule 리스트를 Batch Insert 한다.")
+    @Test
+    void batchInsertTest() {
+        List<Schedule> schedules = List.of(
+                new Schedule(attendee, availableDate, Timeslot.TIME_0000),
+                new Schedule(attendee, availableDate, Timeslot.TIME_0130),
+                new Schedule(attendee, availableDate, Timeslot.TIME_0230)
+        );
+
+        scheduleBatchRepository.batchInsert(schedules);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM schedule", Integer.class);
+        assertThat(count).isEqualTo(schedules.size());
+    }
+}

--- a/backend/src/test/java/kr/momo/domain/schedule/ScheduleRepositoryTest.java
+++ b/backend/src/test/java/kr/momo/domain/schedule/ScheduleRepositoryTest.java
@@ -1,0 +1,68 @@
+package kr.momo.domain.schedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import kr.momo.domain.attendee.Attendee;
+import kr.momo.domain.attendee.AttendeeRepository;
+import kr.momo.domain.availabledate.AvailableDate;
+import kr.momo.domain.availabledate.AvailableDateRepository;
+import kr.momo.domain.meeting.Meeting;
+import kr.momo.domain.meeting.MeetingRepository;
+import kr.momo.domain.timeslot.Timeslot;
+import kr.momo.fixture.AttendeeFixture;
+import kr.momo.fixture.AvailableDateFixture;
+import kr.momo.fixture.MeetingFixture;
+import kr.momo.support.IsolateDatabase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+@IsolateDatabase
+class ScheduleRepositoryTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ScheduleRepository scheduleRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private AttendeeRepository attendeeRepository;
+
+    @Autowired
+    private AvailableDateRepository availableDateRepository;
+
+    private Attendee attendee;
+    private AvailableDate availableDate;
+
+    @BeforeEach
+    void setUp() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.COFFEE.create());
+        attendee = attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
+        availableDate = availableDateRepository.save(AvailableDateFixture.TODAY.create(meeting));
+    }
+
+    @DisplayName("참가자의 스케쥴을 한 번에 삭제한다.")
+    @Test
+    void batchInsertTest() {
+        List<Schedule> schedules = List.of(
+                new Schedule(attendee, availableDate, Timeslot.TIME_0000),
+                new Schedule(attendee, availableDate, Timeslot.TIME_0130),
+                new Schedule(attendee, availableDate, Timeslot.TIME_0230)
+        );
+        scheduleRepository.saveAll(schedules);
+
+        scheduleRepository.deleteByAttendee(attendee);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM schedule", Integer.class);
+        assertThat(count).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #256 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

`saveAll()`, `deleteAll()` 호출 시 엔티티 개수만큼 쿼리가 호출되는 문제를 개선했습니다.

엔티티 수 만큼 쿼리가 호출되었던 이유는 다음과 같습니다.

`saveAll()`과 `deleteAll()` 메서드는 JPA에서 다수의 엔티티를 일괄적으로 처리할 수 있도록 제공하는 기능인데요.
`saveAll()` 내부 구현을 살펴보면 하나의 트랜잭션 안에서 엔티티 수 만큼 반복문을 돌며 `save()`를 호출합니다.
```java
@Transactional
public <S extends T> List<S> saveAll(Iterable<S> entities) {
    Assert.notNull(entities, "Entities must not be null");
    List<S> result = new ArrayList();
    Iterator var4 = entities.iterator();

    while(var4.hasNext()) {
        S entity = (Object)var4.next();
        result.add(this.save(entity));
    }

    return result;
}
```
즉 매번 새로운 트랜잭션을 생성하는 `save()`와 달리 
하나의 트랜잭션 안에서 처리한다는 차이만 존재할 뿐, 엔티티 수 만큼 쿼리가 호출되는 것에는 변함이 없습니다.

이를 해결하는 방법에는 두 가지 방법이 존재합니다.
1. Hibernate가 지원하는 `hibernate.jdbc.batch_size` 옵션을 통한 Batch Update
2. Jdbc 레벨에서 Batch Update를 직접 구현하는 것

Hibernate도 Batch Processing을 위한 `hibernate.jdbc.batch_size` 옵션을 제공하는데요, 
하지만 id 생성 전략이 `AutoIncrement(Identity)` 일 경우, Batch Processing 및 Hibernate 쓰기 지연 철학과 충돌이 발생하고Hibernate는 Jdbc 레벨에서 Batch Processing을 비활성화 시킵니다.

> [12.2. Session batching](https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#batch-session-batch)
>Hibernate disables insert batching at the JDBC level transparently if you use an identity identifier generator.

데이터베이스에 Id 생성 책임을 위임하는 Identity 전략과 서로 이해관계가 맞지 때문입니다.
배치 처리를 위해서는 영속성 컨텍스트에 엔티티를 모아서 처리하는 작업이 필요한데, 
영속화를 위해서는 ID(PK)가 필수적으로 필요하기 때문에 개별 엔티티들을 영속화 하는 시점에 `em.flush()`가 호출되게 됩니다.

따라서 Identity 전략을 사용할 경우 JPA 레벨에서 Batch 처리하는 방법은 존재하지 않습니다.
Sequence 전략은 MySQL이 지원하지 않고있고, Table 전략은 현명한 판단이 아니기 때문에 더 Low 레벨인 Jdbc로 직접 구현하는 방법을 선택했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- `rewriteBatchedStatements=true`
    - DB URL에 해당 옵션을 활성화하면 MySQL JDBC 드라이버가 배치 작업시 여러 쿼리를 하나의 Multi Value 쿼리로 개선하여 성능을 최적화합니다.

배치 사이즈의 경우 예약 생성하는 과정에서 가능한 날짜들을 삽입하는 경우 30
스케쥴 생성 과정에서 삽입하는 경우 500으로 설정하였습니다.

배치 사이즈를 설정할 때에는 `JVM 메모리`와 `DB Packet Size Limit` 두 가지를 고려해야 하는데요, 
너무 작게 설정하면 네트워크 통신 비용이 증가됨에 따라 성능이 하락하고, 너무 크게한다면 어플리케이션과 데이터베이스에 무리를 줄 수 있습니다.

Batch Processing의 철학을 고려해보면 현재보다 사이즈를 크게 설정해도 무리가 없을 것으로 예상하지만, 
아직 실제 환경에서의 부하 데이터가 없고, OLTP 환경임을 고려했을 때 조금 더 방어적으로 설정하는 것이 안전하다고 판단했습니다. 

`MySQL Packet Size Limit`는 명령어로 쉽게 확인할 수 있고, 현재 기본 값은 `67108864B`, `64MB`입니다.
따라서 하나의 레코드 사이즈를 계산할 수 있으면 한 번에 몇 개 데이터까지 전송할 수 있는지 대략적으로 파악할 수 있습니다.

1000만개가 들어있는 Schedule 테이블의 data length는 `711,983,104B` 인 것을 확인했고 계산해봤을 때 하나의 레코드당 대략 `71B`.
67108864B/71B 를 하면 `945,195`라는 수치가 나오니 약 94만개 까지는 한 번에 전송할 수 있다는 결론을 얻을 수 있습니다.

## 레퍼런스

- https://docs.spring.io/spring-framework/reference/data-access/jdbc/advanced.html
- https://stackoverflow.com/questions/27697810/why-does-hibernate-disable-insert-batching-when-using-an-identity-identifier-gen/27732138#27732138
- https://dev.mysql.com/doc/connectors/en/connector-j-connp-props-performance-extensions.html
- https://techblog.woowahan.com/2695/
