### PR TITLE
[BE] 지표 설정 관련 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 
     implementation 'com.auth0:java-jwt:4.4.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -6,6 +6,7 @@ spring:
       - ${SECURITY_PATH:classpath:security}/jwt.yml
       - ${SECURITY_PATH:classpath:security}/cors.yml
       - ${SECURITY_PATH:classpath:security}/logback.yml
+      - ${SECURITY_PATH:classpath:security}/actuator.yml
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -31,3 +31,16 @@ security:
 
 log:
   directory: ./logs
+
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      exposure:
+        include: prometheus
+    jmx:
+      exposure:
+        exclude: "*"
+  endpoint:
+    prometheus:
+      enabled: true

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -6,6 +6,7 @@ spring:
       - ${SECURITY_PATH:classpath:security}/jwt.yml
       - ${SECURITY_PATH:classpath:security}/cors.yml
       - ${SECURITY_PATH:classpath:security}/logback.yml
+      - ${SECURITY_PATH:classpath:security}/actuator.yml
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,9 +9,3 @@ spring:
 
 server:
   port: 8080
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: prometheus

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,3 +9,9 @@ spring:
 
 server:
   port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus


### PR DESCRIPTION
## 관련 이슈

- resolves: #248 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- JVM, Connection Pool 등 서비스의 지표를 얻기 위해서는 `spring actuator`의 의존성이 필요합니다.
- grafana를 이용하여 지표를 확인하기 위해선 서비스에서 지표들을 요청하여 받아가는 `spring prometheus`가 필요합니다.
- 그렇게 때문에 관련 2가지 의존성과 `/actuator/prometheus`의 경로를 열어주었습니다.
- 🚨 해당 경로는 서비스의 민감한 정보를 담은 지표들이기 때문에 외부에서 접속할 수 없도록 추가적인 설정이 필요합니다.

## 특이 사항

`/actuator/prometheus`를 배포 환경인 dev와 prod 환경에서 탐지하지 못하도록 보안 강화를 적용하였습니다.
서브모듈이 변경되었으니 `update` 부탁드립니다~
