### PR TITLE
[BE] 확정 약속 조회 시 hostName 정보 추가

### DIFF
--- a/backend/src/main/java/kr/momo/controller/annotation/ApiErrorResponse.java
+++ b/backend/src/main/java/kr/momo/controller/annotation/ApiErrorResponse.java
@@ -75,4 +75,18 @@ public @interface ApiErrorResponse {
     @interface NotFound {
         @AliasFor(annotation = ApiResponse.class, attribute = "description") String value() default "";
     }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Operation
+    @ApiResponse(
+            responseCode = "500",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = CustomProblemDetail.class)
+            )
+    )
+    @interface InternalServerError {
+        @AliasFor(annotation = ApiResponse.class, attribute = "description") String value() default "";
+    }
 }

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingControllerDocs.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingControllerDocs.java
@@ -75,6 +75,9 @@ public interface MeetingControllerDocs {
             | NOT_FOUND_MEETING | 존재하지 않는 약속 정보 입니다. |
             | NOT_CONFIRMED | 아직 확정되지 않은 약속입니다. |
             """)
+    @ApiErrorResponse.InternalServerError(ERROR_CODE_TABLE_HEADER + """
+            | HOST_NOT_FOUND | 약속의 주최자 정보를 찾을 수 없습니다. 관리자에게 문의하세요. |
+            """)
     MomoApiResponse<ConfirmedMeetingResponse> findConfirmedMeeting(
             @PathVariable @Schema(description = "약속 UUID") String uuid
     );

--- a/backend/src/main/java/kr/momo/domain/attendee/AttendeeGroup.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/AttendeeGroup.java
@@ -81,12 +81,9 @@ public class AttendeeGroup {
     }
 
     public Optional<Attendee> findHost() {
-        for (Attendee attendee : attendees) {
-            if (attendee.isHost()) {
-                return Optional.of(attendee);
-            }
-        }
-        return Optional.empty();
+        return attendees.stream()
+                .dropWhile(attendee -> !attendee.isHost())
+                .findFirst();
     }
 
     @Override

--- a/backend/src/main/java/kr/momo/domain/attendee/AttendeeGroup.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/AttendeeGroup.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import kr.momo.exception.MomoException;
@@ -77,6 +78,15 @@ public class AttendeeGroup {
 
     public boolean isSameSize(AttendeeGroup attendeeGroup) {
         return attendees.size() == attendeeGroup.size();
+    }
+
+    public Optional<Attendee> findHost() {
+        for (Attendee attendee : attendees) {
+            if (attendee.isHost()) {
+                return Optional.of(attendee);
+            }
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/backend/src/main/java/kr/momo/domain/attendee/AttendeeGroup.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/AttendeeGroup.java
@@ -86,6 +86,12 @@ public class AttendeeGroup {
                 .findFirst();
     }
 
+    public List<String> names() {
+        return attendees.stream()
+                .map(Attendee::name)
+                .toList();
+    }
+
     @Override
     public boolean equals(Object object) {
         if (this == object) {

--- a/backend/src/main/java/kr/momo/domain/meeting/ConfirmedMeeting.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/ConfirmedMeeting.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import kr.momo.domain.BaseEntity;
 import kr.momo.domain.attendee.Attendee;
+import kr.momo.domain.attendee.AttendeeGroup;
 import kr.momo.domain.schedule.Schedule;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -51,15 +52,16 @@ public class ConfirmedMeeting extends BaseEntity {
         this.endDateTime = endDateTime;
     }
 
-    public List<Attendee> availableAttendeesOf(List<Schedule> schedules) {
+    public AttendeeGroup availableAttendeesOf(List<Schedule> schedules) {
         Map<Attendee, Long> groupAttendeeByScheduleCount = schedules.stream()
                 .filter(this::isScheduleWithinDateTimeRange)
                 .collect(groupingBy(Schedule::getAttendee, counting()));
 
         long confirmedTimeSlotCount = countTimeSlotOfConfirmedMeeting();
-        return groupAttendeeByScheduleCount.keySet().stream()
+        List<Attendee> availableAttendees = groupAttendeeByScheduleCount.keySet().stream()
                 .filter(key -> groupAttendeeByScheduleCount.get(key) == confirmedTimeSlotCount)
                 .toList();
+        return new AttendeeGroup(availableAttendees);
     }
 
     private boolean isScheduleWithinDateTimeRange(Schedule schedule) {

--- a/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
@@ -12,7 +12,8 @@ public enum AttendeeErrorCode implements ErrorCodeType {
     NOT_FOUND_ATTENDEE(HttpStatus.NOT_FOUND, "해당 약속에 참여하는 참가자 정보가 없습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     DUPLICATED_ATTENDEE_NAME(HttpStatus.BAD_REQUEST, "참여자의 이름이 중복됩니다."),
-    INVALID_ATTENDEE_SIZE(HttpStatus.BAD_REQUEST, "참여자의 수는 최소 1명입니다.");
+    INVALID_ATTENDEE_SIZE(HttpStatus.BAD_REQUEST, "참여자의 수는 최소 1명입니다."),
+    HOST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "약속의 주최자 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
@@ -13,7 +13,7 @@ public enum AttendeeErrorCode implements ErrorCodeType {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근이 거부되었습니다."),
     DUPLICATED_ATTENDEE_NAME(HttpStatus.BAD_REQUEST, "참여자의 이름이 중복됩니다."),
     INVALID_ATTENDEE_SIZE(HttpStatus.BAD_REQUEST, "참여자의 수는 최소 1명입니다."),
-    HOST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "약속의 주최자 정보를 찾을 수 없습니다.");
+    HOST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "약속의 주최자 정보를 찾을 수 없습니다. 관리자에게 문의하세요."),;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingConfirmService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingConfirmService.java
@@ -112,7 +112,7 @@ public class MeetingConfirmService {
         Attendee host = attendees.findHost()
                 .orElseThrow(() -> new MomoException(AttendeeErrorCode.HOST_NOT_FOUND));
         List<Schedule> schedules = scheduleRepository.findAllByAttendeeIn(attendees.getAttendees());
-        List<Attendee> availableAttendees = confirmedMeeting.availableAttendeesOf(schedules);
+        AttendeeGroup availableAttendees = confirmedMeeting.availableAttendeesOf(schedules);
 
         return ConfirmedMeetingResponse.from(meeting, host, availableAttendees, confirmedMeeting);
     }

--- a/backend/src/main/java/kr/momo/service/meeting/dto/ConfirmedMeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/ConfirmedMeetingResponse.java
@@ -13,6 +13,7 @@ import kr.momo.domain.meeting.Meeting;
 
 public record ConfirmedMeetingResponse(
         String meetingName,
+        String hostName,
         List<String> availableAttendeeNames,
         @JsonFormat(pattern = "yyyy-MM-dd", shape = Shape.STRING)
         LocalDate startDate,
@@ -27,10 +28,11 @@ public record ConfirmedMeetingResponse(
 ) {
 
     public static ConfirmedMeetingResponse from(
-            Meeting meeting, List<Attendee> attendees, ConfirmedMeeting confirmedMeeting
+            Meeting meeting, Attendee host, List<Attendee> attendees, ConfirmedMeeting confirmedMeeting
     ) {
         return new ConfirmedMeetingResponse(
                 meeting.getName(),
+                host.name(),
                 attendees.stream().map(Attendee::name).toList(),
                 confirmedMeeting.getStartDateTime().toLocalDate(),
                 confirmedMeeting.getStartDateTime().toLocalTime(),

--- a/backend/src/main/java/kr/momo/service/meeting/dto/ConfirmedMeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/ConfirmedMeetingResponse.java
@@ -8,6 +8,7 @@ import java.time.format.TextStyle;
 import java.util.List;
 import java.util.Locale;
 import kr.momo.domain.attendee.Attendee;
+import kr.momo.domain.attendee.AttendeeGroup;
 import kr.momo.domain.meeting.ConfirmedMeeting;
 import kr.momo.domain.meeting.Meeting;
 
@@ -28,12 +29,12 @@ public record ConfirmedMeetingResponse(
 ) {
 
     public static ConfirmedMeetingResponse from(
-            Meeting meeting, Attendee host, List<Attendee> attendees, ConfirmedMeeting confirmedMeeting
+            Meeting meeting, Attendee host, AttendeeGroup attendees, ConfirmedMeeting confirmedMeeting
     ) {
         return new ConfirmedMeetingResponse(
                 meeting.getName(),
                 host.name(),
-                attendees.stream().map(Attendee::name).toList(),
+                attendees.names(),
                 confirmedMeeting.getStartDateTime().toLocalDate(),
                 confirmedMeeting.getStartDateTime().toLocalTime(),
                 confirmedMeeting.getStartDateTime().getDayOfWeek().getDisplayName(TextStyle.NARROW, Locale.KOREAN),

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -409,7 +409,8 @@ class MeetingControllerTest {
     @Test
     void confirmInvalidRequest() {
         Meeting meeting = createLockedMovieMeeting();
-        AvailableDate availableDate = availableDateRepository.save(new AvailableDate(LocalDate.now().plusDays(1), meeting));
+        AvailableDate availableDate = availableDateRepository.save(
+                new AvailableDate(LocalDate.now().plusDays(1), meeting));
         String tomorrow = availableDate.getDate().format(DateTimeFormatter.ISO_DATE);
         Attendee guest = attendeeRepository.save(AttendeeFixture.GUEST_MARK.create(meeting));
         String token = getToken(guest, meeting);
@@ -490,6 +491,7 @@ class MeetingControllerTest {
         Meeting meeting = MeetingFixture.MOVIE.create();
         meeting.lock();
         meeting = meetingRepository.save(meeting);
+        attendeeRepository.save(AttendeeFixture.HOST_JAZZ.create(meeting));
         confirmedMeetingRepository.save(ConfirmedMeetingFixture.MOVIE.create(meeting));
 
         RestAssured.given().log().all()

--- a/backend/src/test/java/kr/momo/domain/meeting/ConfirmedMeetingTest.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/ConfirmedMeetingTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import kr.momo.domain.attendee.Attendee;
+import kr.momo.domain.attendee.AttendeeGroup;
 import kr.momo.domain.availabledate.AvailableDate;
 import kr.momo.domain.schedule.Schedule;
 import kr.momo.domain.timeslot.Timeslot;
@@ -37,7 +38,8 @@ class ConfirmedMeetingTest {
                 new Schedule(attendee2, new AvailableDate(today, meeting), Timeslot.TIME_0000)
         );
 
-        List<Attendee> attendees = confirmedMeeting.availableAttendeesOf(schedules);
+        AttendeeGroup availableAttendees = confirmedMeeting.availableAttendeesOf(schedules);
+        List<Attendee> attendees = availableAttendees.getAttendees();
 
         assertAll(
                 () -> assertThat(attendees).hasSize(1),


### PR DESCRIPTION
## 관련 이슈

- resolves: #280 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

프론트엔드에서 '확정 취소' 버튼을 host일 경우에만 보여줘야 하는데 다음과 같은 상황이 발생하기 때문에 hostName 정보 추가 요청이 들어왔습니다.

hostName에 대한 정보를 가지고 있는 경우가 아래의 2가지 경우입니다.
1. 약속생성 시 사용자가 인풋 필드에 기입한 name (클라이언트)
2. 약속 정보 조회시 response 값

1번 or 2번으로 얻은 hostName을 확정 취소 페이지에서 쓰려면 
1. 확정 취소 페이지까지 navigate 함수로 hostName 전달 + 인자로 내려주기 or 2. 전역으로 저장
하는 복잡한 경우가 발생합니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- AttendeeGroup에 옵셔널로 Host인 Attendee를 반환하는 메서드를 추가했습니다.
- AttendeeErrorCode.HOST_NOT_FOUND 추가했습니다.
- 따로 hostName을 반환하는 API를 추가할지 고민이 되었으나 추가로 필요한 상황이 없고 런칭데이 까지 얼마 남지 않았기 때문에 분리하지 않았습니다. 다른 곳에서도 get hostName api가 필요하게 된다면 분리하는 것을 고려하고 있습니다.

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->

- 약속의 모든 참여자에서 주최자가 존재하지 않는다면 서버측의 문제가 있다고 생각하여 AttendeeErrorCode.HOST_NOT_FOUND를 500번 상태 코드로 설정했습니다. 문제가 되는 부분이 있다면 리뷰 부탁 드립니다.
