### PR TITLE
[FE] 약속 시간을 설정할 때 되는/안되는 시간을 구분해서 설정할 수 있도록 기능 추가

### DIFF
--- a/frontend/src/components/Schedules/SchedulePicker/index.tsx
+++ b/frontend/src/components/Schedules/SchedulePicker/index.tsx
@@ -1,4 +1,5 @@
-import { useContext } from 'react';
+import { css } from '@emotion/react';
+import { useContext, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { MeetingDateTime } from 'types/meeting';
 import type { MeetingSingleSchedule } from 'types/schedule';
@@ -31,6 +32,11 @@ interface SchedulePickerProps extends MeetingDateTime {
   meetingSingleSchedule: MeetingSingleSchedule;
 }
 
+const TIME_SELECT_MODE = {
+  available: '되는',
+  unavailable: '안되는',
+} as const;
+
 export default function SchedulePicker({
   firstTime,
   lastTime,
@@ -53,6 +59,7 @@ export default function SchedulePicker({
     tableRef,
     tableValue,
     currentTableValue,
+    resetTableValue,
     currentDates,
     isMultiPage,
     increaseDatePage,
@@ -66,12 +73,42 @@ export default function SchedulePicker({
   );
 
   const handleOnToggle = () => {
-    const convert = convertToSchedule(tableValue, availableDates, firstTime, lastTime);
+    const convert = convertToSchedule({
+      availableDates,
+      firstTime,
+      lastTime,
+      selectedScheduleTable: tableValue,
+      selectMode,
+    });
+
     postScheduleMutate({ uuid, requestData: convert });
+  };
+
+  const [selectMode, setSelectMode] = useState<keyof typeof TIME_SELECT_MODE>('available');
+  const handleSelectModeChange = (mode: keyof typeof TIME_SELECT_MODE) => {
+    if (selectMode === mode) return;
+
+    resetTableValue();
+    setSelectMode(mode);
   };
 
   return (
     <div css={s_relativeContainer}>
+      <div
+        css={css`
+          display: flex;
+          gap: 0.4rem;
+        `}
+      >
+        <button onClick={() => handleSelectModeChange('available')}>
+          {TIME_SELECT_MODE.available}
+        </button>
+        <p>/</p>
+        <button onClick={() => handleSelectModeChange('unavailable')}>
+          {TIME_SELECT_MODE.unavailable}
+        </button>
+        <p>시간으로 선택하기</p>
+      </div>
       {isMultiPage && (
         <div css={s_datesControlButtonContainer}>
           <button

--- a/frontend/src/components/Schedules/Schedules.util.ts
+++ b/frontend/src/components/Schedules/Schedules.util.ts
@@ -18,13 +18,6 @@ export const formatDate = (dateString: string) => {
   } as const;
 };
 
-export const formatTime = (time: string) => {
-  const hour = parseInt(time);
-  const hourPrefix = hour >= 12 ? '오후' : '오전';
-
-  return `${hourPrefix} ${hour % 12 || 12}시`;
-};
-
 export const generateTimeRange = (firstTime: string, lastTime: string): number[] => {
   const start = parseInt(firstTime.slice(0, 2));
   const end = parseInt(lastTime.slice(0, 2));

--- a/frontend/src/hooks/usePagedTimePick/usePagedTimePick.ts
+++ b/frontend/src/hooks/usePagedTimePick/usePagedTimePick.ts
@@ -9,6 +9,7 @@ interface UseTimePickReturn {
   tableRef: React.MutableRefObject<HTMLTableElement | null>;
   currentTableValue: number[][];
   tableValue: number[][];
+  resetTableValue: () => void;
 }
 
 type UsePagedTimePickHook = (
@@ -29,6 +30,7 @@ type UsePagedTimePickHook = (
  * * 아래는 usePagedTimePick 훅 반환 타입에 대한 간단한 설명입니다. :)
  * @property {React.MutableRefObject<HTMLTableElement | null>} tableRef - 테이블 요소의 참조 객체
  * @property {number[][]} tableValue - 전체 테이블 값
+ * @property {() => void} resetTableValue - 시간 테이블을 초기화하는 함수
  * @property {number[][]} currentTableValue - 현재 페이지에 해당하는 테이블 값
  * @property {number} currentDatePage - 현재 날짜 페이지 인덱스
  * @property {string[]} currentDates - 현재 페이지에 해당하는 날짜 배열
@@ -50,7 +52,7 @@ const usePagedTimePick: UsePagedTimePickHook = (availableDates, initialSchedules
     isLastPage,
   } = useDatePage(availableDates);
 
-  const { tableRef, tableValue } = useTimePick(initialSchedules, currentDatePage);
+  const { tableRef, tableValue, resetTableValue } = useTimePick(initialSchedules, currentDatePage);
 
   const currentTableValue = useMemo(
     () =>
@@ -64,6 +66,7 @@ const usePagedTimePick: UsePagedTimePickHook = (availableDates, initialSchedules
     tableRef,
     tableValue,
     currentTableValue,
+    resetTableValue,
     currentDatePage,
     currentDates,
     increaseDatePage,

--- a/frontend/src/hooks/useTimePick/useTimePick.ts
+++ b/frontend/src/hooks/useTimePick/useTimePick.ts
@@ -96,6 +96,11 @@ export default function useTimePick(initialTableValue: number[][], currentDatePa
     }
   }, []);
 
+  const resetTableValue = useCallback(() => {
+    const resetValue = initialTableValue.map((tableRow) => tableRow.map(() => 0)); // 모든 원소를 0으로 변경하는 방법을 사용해서 초기화합니다.(@해리)
+    setTableValue(resetValue);
+  }, [initialTableValue]);
+
   useEffect(() => {
     const node = tableRef.current?.querySelector('tbody') ?? tableRef.current;
 
@@ -120,5 +125,5 @@ export default function useTimePick(initialTableValue: number[][], currentDatePa
     };
   }, [handleTimePickStart, handlePickedTimeChange, handlePointerEnd]);
 
-  return { tableRef, tableValue } as const;
+  return { tableRef, tableValue, resetTableValue } as const;
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #269 

약속 시간을 설정할 때, 되는/안되는 시간을 구분해서 설정할 수 있는 기능을 추가했습니다.

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

### 구현 과정

1. `되는 / 안되는`을 구분할 수 있는 클라이언트 상태를 추가한다.
2. 되는 / 안되는 상태에 따라서 사용자가 테이블을 드래그할 때 강조되는 색을 변경한다.
(안되는 시간을 선택할 경우 어떤 색을 사용해서 구분할지는 확실하게 정해지지 않아서 일단 같은 색을 사용한 후 PR 날립니다.)  
3. 되는 / 안되는 상태에 맞춰 서버에 전달해줘야 하는 데이터를 생성한다.  
4. 기존에 되는 / 안되는 상태로 선택한 시간들이 있는 경우에 선택 모드를 변경할 경우 기존에 선택한 시간은 자동으로 초기화 될 수 있도록 한다  
 **->** 모달 UI가 만들어지면 모달을 사용해서 초기화가 될 수 있는데도 선택 모드를 변경하겠냐는 질문을 한 후, 초기화 할 수 있도록 한다
(아직 모달은 구현되지 않았기 때문에 레벨 4에서 추가적으로 구현하면 사용하게 될 것 같아요.)

## 특이 사항

### 반복문을 한 번 돌 때마다 if문으로 분기 처리 vs 코드가 한 줄 다른 두 개의 함수 구현

`generateAvailableSchedules`, `generateUnavailableSchedules` 함수는 한 글자 차이 밖에 나지 않습니다.

```
if (row[colIndex])
if (!row[colIndex])
```

그럼에도 불구하고 두 개의 함수로 구분한 이유는, 

```ts
return availableDates
    .map((date, colIndex) => {
      const times: string[] = [];

      selectedScheduleTable.forEach((row, rowIndex) => {
        // isAvailable에 따라 분기 처리
        if (isAvailable ? row[colIndex] : !row[colIndex]) {
          times.push(timeSlots[rowIndex]);
        }
      });

      return { date, times };
    })
    .filter((schedule) => schedule.times.length > 0);
```
반복문을 돌 때마다, if문을 사용해서 분기처리를 하는 것 보다는 코드가 한 줄 다른 두 개의 함수를 만드는 것이 더 낫다고 판단했기 때문입니다. 두 구현에 대한 성능 차이는 측정해보지 않았지만, 

- 함수 이름을 통해서 동작을 확실하게 구분할 수 있는 점
- 매 반복문마다 분기처리를 하지 않아도 된다는 점

이 두 장점을 우선적으로 생각해 보기로 했어요.
참고 부탁드립니다 :)


<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
