### PR TITLE
[BE] 쿠키 헤더의 SameSite 옵션을 변경

### DIFF
--- a/backend/src/main/java/kr/momo/controller/CookieManager.java
+++ b/backend/src/main/java/kr/momo/controller/CookieManager.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 public class CookieManager {
 
     private static final String ACCESS_TOKEN = "ACCESS_TOKEN";
-    private static final String SAME_SITE_OPTION = "None";
     private static final long SESSION_COOKIE_AGE = -1;
     private static final long EXPIRED_COOKIE_AGE = 0;
 
@@ -32,7 +31,6 @@ public class CookieManager {
                 .secure(true)
                 .domain(cookieDomain)
                 .path(path)
-                .sameSite(SAME_SITE_OPTION)
                 .maxAge(maxAge)
                 .build()
                 .toString();


### PR DESCRIPTION
## 관련 이슈

- resolves: #293 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

개발 편의를 위해 이전에 쿠키 헤더의 SameSite 옵션을 None으로 변경했었는데요
None으로 설정했던 코드 라인을 제거하고 보안을 강화합니다.

SameSite 옵션을 명시적으로 설정하지 않으면 브라우저의 기본 설정을 따르게 됩니다.
Internet Explorer를 제외한 대부분의 최신 브라우저는 현재 SameSite = Lax 모드를 사용하고 있습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
