### PR TITLE
[BE] 약속의 UUID 발급 방식을 개선

### DIFF
--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingControllerDocs.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingControllerDocs.java
@@ -29,9 +29,12 @@ public interface MeetingControllerDocs {
     @ApiErrorResponse.BadRequest(ERROR_CODE_TABLE_HEADER + """
             | INVALID_NAME_LENGTH | 이름 길이는 1자 이상 5자 이하 까지 가능합니다. |
             | INVALID_PASSWORD_LENGTH | 비밀번호 길이는 1자 이상 10자 이하 까지 가능합니다. |
+            | PAST_NOT_PERMITTED | 과거 날짜로는 약속을 생성할 수 없습니다. |
+            """)
+    @ApiErrorResponse.InternalServerError(ERROR_CODE_TABLE_HEADER + """
+            | UUID_GENERATION_FAILURE | 약속 생성 과정 중 키 생성에 실패했습니다. 잠시 후 다시 시도해주세요. |
             """)
     ResponseEntity<MomoApiResponse<MeetingCreateResponse>> create(@RequestBody @Valid MeetingCreateRequest request);
-
 
     @Operation(
             summary = "약속 확정",
@@ -49,7 +52,7 @@ public interface MeetingControllerDocs {
             """)
     @ApiErrorResponse.Unauthorized(ERROR_CODE_TABLE_HEADER + """
             | UNAUTHORIZED_TOKEN | 유효하지 않은 토큰입니다. |
-             """)
+            """)
     @ApiErrorResponse.Forbidden(ERROR_CODE_TABLE_HEADER + """
             | ACCESS_DENIED | 접근이 거부되었습니다. |
             """)

--- a/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/Meeting.java
@@ -28,7 +28,7 @@ public class Meeting extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column(nullable = false, length = 40)
+    @Column(nullable = false, length = 8)
     private String uuid;
 
     @Column(nullable = false)

--- a/backend/src/main/java/kr/momo/domain/meeting/MeetingRepository.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/MeetingRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     Optional<Meeting> findByUuid(String uuid);
+
+    boolean existsByUuid(String uuid);
 }

--- a/backend/src/main/java/kr/momo/domain/meeting/RandomUuidGenerator.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/RandomUuidGenerator.java
@@ -1,0 +1,13 @@
+package kr.momo.domain.meeting;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomUuidGenerator implements UuidGenerator {
+
+    @Override
+    public String generateUuid(int length) {
+        return RandomStringUtils.randomAlphanumeric(length);
+    }
+}

--- a/backend/src/main/java/kr/momo/domain/meeting/UuidGenerator.java
+++ b/backend/src/main/java/kr/momo/domain/meeting/UuidGenerator.java
@@ -1,0 +1,6 @@
+package kr.momo.domain.meeting;
+
+public interface UuidGenerator {
+
+    String generateUuid(int length);
+}

--- a/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/MeetingErrorCode.java
@@ -13,6 +13,7 @@ public enum MeetingErrorCode implements ErrorCodeType {
     INVALID_DATETIME_RANGE(HttpStatus.BAD_REQUEST, "날짜 또는 시간이 잘못되었습니다."),
     PAST_NOT_PERMITTED(HttpStatus.BAD_REQUEST, "과거 날짜로는 약속을 생성할 수 없습니다."),
     NOT_CONFIRMED(HttpStatus.NOT_FOUND, "아직 확정되지 않은 약속입니다."),
+    UUID_GENERATION_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "약속 생성 과정 중 키 생성에 실패했습니다. 잠시 후 다시 시도해주세요."),
     MEETING_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "약속 정보를 불러오는데 실패했습니다. 약속을 다시 생성해주세요.");
 
     private final HttpStatus httpStatus;

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -12,6 +12,7 @@ import kr.momo.domain.availabledate.AvailableDateRepository;
 import kr.momo.domain.availabledate.AvailableDates;
 import kr.momo.domain.meeting.Meeting;
 import kr.momo.domain.meeting.MeetingRepository;
+import kr.momo.domain.meeting.UuidGenerator;
 import kr.momo.exception.MomoException;
 import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
@@ -21,7 +22,6 @@ import kr.momo.service.meeting.dto.MeetingCreateResponse;
 import kr.momo.service.meeting.dto.MeetingResponse;
 import kr.momo.service.meeting.dto.MeetingSharingResponse;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +34,7 @@ public class MeetingService {
 
     private final JwtManager jwtManager;
     private final Clock clock;
+    private final UuidGenerator uuidGenerator;
     private final MeetingRepository meetingRepository;
     private final AvailableDateRepository availableDateRepository;
     private final AttendeeRepository attendeeRepository;
@@ -60,7 +61,7 @@ public class MeetingService {
 
     private String generateUniqueUuid() {
         for (int attempts = 0; attempts < MAX_UUID_GENERATION_ATTEMPTS; attempts++) {
-            String uuid = RandomStringUtils.randomAlphanumeric(SHORT_UUID_LENGTH);
+            String uuid = uuidGenerator.generateUuid(SHORT_UUID_LENGTH);
             if (!meetingRepository.existsByUuid(uuid)) {
                 return uuid;
             }

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -60,14 +60,19 @@ public class MeetingService {
     }
 
     private String generateUniqueUuid() {
-        for (int attempts = 0; attempts < MAX_UUID_GENERATION_ATTEMPTS; attempts++) {
-            String uuid = uuidGenerator.generateUuid(SHORT_UUID_LENGTH);
-            if (!meetingRepository.existsByUuid(uuid)) {
-                return uuid;
-            }
+        String uuid;
+        int attempts = 0;
+
+        do {
+            uuid = uuidGenerator.generateUuid(SHORT_UUID_LENGTH);
+            attempts++;
+        } while (meetingRepository.existsByUuid(uuid) && attempts < MAX_UUID_GENERATION_ATTEMPTS);
+
+        if (attempts >= MAX_UUID_GENERATION_ATTEMPTS) {
+            throw new MomoException(MeetingErrorCode.UUID_GENERATION_FAILURE);
         }
 
-        throw new MomoException(MeetingErrorCode.UUID_GENERATION_FAILURE);
+        return uuid;
     }
 
     private void validateNotPast(AvailableDates meetingDates) {

--- a/backend/src/test/java/kr/momo/domain/meeting/fake/FakeUuidGenerator.java
+++ b/backend/src/test/java/kr/momo/domain/meeting/fake/FakeUuidGenerator.java
@@ -1,0 +1,18 @@
+package kr.momo.domain.meeting.fake;
+
+import kr.momo.domain.meeting.UuidGenerator;
+
+public class FakeUuidGenerator implements UuidGenerator {
+
+    private static final String BASE_FAKE_UUID = "Momo";
+
+    @Override
+    public String generateUuid(int length) {
+        StringBuilder uuid = new StringBuilder();
+        while (uuid.length() < length) {
+            uuid.append(BASE_FAKE_UUID);
+        }
+
+        return uuid.substring(0, length);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- resolves: #296 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

`java.util` 이 제공하는 `UUID` 클래스의 버전4 UUID 생성 방식에서 영어 대소문자, 숫자를 포함하는 8글자 랜덤 문자열 생성방식으로 변경하였습니다.

현재 사용하는 버전 4 UUID는 36자 문자열의 형태를 이루어 매우 높은 고유성을 보장하는 장점이 있습니다. 하지만 길이가 다소 길어 메모리, 테이블 저장공간, 인덱스를 관리하는 측면에서 여러가지 단점을 가지고 있다고 판단하였습니다.

길이를 8글자로 변경할 경우 약 218조 개의 고유한 문자열을 생성할 수 있고
Birthday Problem 공식에 따라 UUID 1740만개를 생성했을 때 부터 충돌 가능성이 50%인 것을 확인할 수 있습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
