### PR TITLE
[FE] 중복 선언된 alert 제거

### DIFF
--- a/frontend/src/components/_common/Header/index.tsx
+++ b/frontend/src/components/_common/Header/index.tsx
@@ -23,8 +23,6 @@ export default function Header() {
   const handleAuthButtonClick = async () => {
     if (isLoggedIn) {
       postLogoutMutate(uuid);
-
-      alert('로그아웃 되었습니다 :)');
     } else {
       navigate(`/meeting/${uuid}/login`);
     }


### PR DESCRIPTION
## 관련 이슈

- resolves: #316 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

로그아웃 시, alert가 두번 출력되는 현상 해결

=> 원인 : user mutation 레이어 분리 시, 해당 alert를 중복해서 선언했습니다. 따라서 mutation에 있는 alert를 유지하고 Header의  alert를 제거했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- 현재 alert는 UI로직인데 서버 상태관리 로직인 useMutation의 onSuccess 내부에서 사용되고 있는데, 추후 수정이 필요합니다.

- [x] 중복 선언된 alert 제거

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
