### PR TITLE
[FE] build:dev 스크립트에서 노드 환경을 production으로 수정

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "prod": "webpack server --open --config webpack.prod.js",
     "dev": "webpack server --open --config webpack.dev.js",
     "build:prod": "NODE_ENV=production webpack --config webpack.prod.js && npm run sentry:sourcemaps",
-    "build:dev": "NODE_ENV=development webpack --config webpack.dev.js",
+    "build:dev": "NODE_ENV=production webpack --config webpack.prod.js",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject ./dist && sentry-cli sourcemaps upload -o momo2024 -p momo-harry-test /dist",
     "lint:css": "stylelint '**/*.styles.ts' --fix",
     "test": "jest",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "prod": "webpack server --open --config webpack.prod.js",
     "dev": "webpack server --open --config webpack.dev.js",
     "build:prod": "NODE_ENV=production webpack --config webpack.prod.js && npm run sentry:sourcemaps",
-    "build:dev": "NODE_ENV=production webpack --config webpack.dev.js",
+    "build:dev": "NODE_ENV=development webpack --config webpack.dev.js",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject ./dist && sentry-cli sourcemaps upload -o momo2024 -p momo-harry-test /dist",
     "lint:css": "stylelint '**/*.styles.ts' --fix",
     "test": "jest",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,6 +11,8 @@ import theme from '@styles/theme';
 import App from './App';
 
 const enableMocking = async () => {
+  if (process.env.REACT_APP_ENABLE_MSW && process.env.REACT_APP_ENABLE_MSW === 'false') return;
+
   if (process.env.NODE_ENV !== 'development') {
     return;
   }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,8 +11,6 @@ import theme from '@styles/theme';
 import App from './App';
 
 const enableMocking = async () => {
-  if (process.env.REACT_APP_ENABLE_MSW && process.env.REACT_APP_ENABLE_MSW === 'false') return;
-
   if (process.env.NODE_ENV !== 'development') {
     return;
   }


### PR DESCRIPTION
Reverts woowacourse-teams/2024-momo#326

현재 development 모드로 배포 시, MSW에러가 발생하므로 해결할 방법을 추후에 찾아보고
우선적으로 production 모드로 배포하도록 수정했습니다.
