### PR TITLE
[FE] 시간 선택 Dropdown value 수정

### DIFF
--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
@@ -56,15 +56,19 @@ describe('useTimeRangeDropdown', () => {
     expect(result.current.endTime.value).toBe(CHANGE_END_TIME);
   });
 
-  it('시작 시간(startTime)을 선택하면, 끝 시간은 1시간 이후로 자동 설정된다.', () => {
-    const CHANGE_START_TIME = '18:00';
-    const CHANGE_END_TIME = '19:00';
-    const { result } = renderHook(() => useTimeRangeDropdown());
+  it.each([
+    ['18:00', '19:00'],
+    ['06:00', '07:00'],
+  ])(
+    '시작 시간(startTime)을 선택하면, 끝 시간은 1시간 이후로 자동 설정된다.',
+    (startTime, endTime) => {
+      const { result } = renderHook(() => useTimeRangeDropdown());
 
-    act(() => {
-      result.current.handleStartTimeChange(CHANGE_START_TIME);
-    });
+      act(() => {
+        result.current.handleStartTimeChange(startTime);
+      });
 
-    expect(result.current.endTime.value).toBe(CHANGE_END_TIME);
-  });
+      expect(result.current.endTime.value).toBe(endTime);
+    },
+  );
 });

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
@@ -55,4 +55,16 @@ describe('useTimeRangeDropdown', () => {
 
     expect(result.current.endTime.value).toBe(CHANGE_END_TIME);
   });
+
+  it('시작 시간(startTime)을 선택하면, 끝 시간은 1시간 이후로 자동 설정된다.', () => {
+    const CHANGE_START_TIME = '18:00';
+    const CHANGE_END_TIME = '19:00';
+    const { result } = renderHook(() => useTimeRangeDropdown());
+
+    act(() => {
+      result.current.handleStartTimeChange(CHANGE_START_TIME);
+    });
+
+    expect(result.current.endTime.value).toBe(CHANGE_END_TIME);
+  });
 });

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
@@ -48,7 +48,7 @@ describe('useTimeRangeDropdown', () => {
     ['18:00', '19:00'],
     ['06:00', '07:00'],
   ])(
-    '시작 시간(startTime)을 선택하면, 끝 시간은 1시간 이후로 자동 설정된다.',
+    '시작 시간(%s)을 선택하면, 끝 시간은 1시간 이후인 %s로 자동 설정된다.',
     (startTime, endTime) => {
       const { result } = renderHook(() => useTimeRangeDropdown());
 

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.test.ts
@@ -12,18 +12,6 @@ describe('useTimeRangeDropdown', () => {
     expect(result.current.endTime.value).toBe(INITIAL_END_TIME);
   });
 
-  it('시작 시간(startTime)을 선택하면 끝 시간(endTime)은 시작 시간(startTime)의 1시간 이후로 설정된다.', () => {
-    const CHANGE_TIME = '01:00';
-    const CHANGE_TIME_AFTER_HOUR = '02:00';
-    const { result } = renderHook(() => useTimeRangeDropdown());
-
-    act(() => {
-      result.current.handleStartTimeChange(CHANGE_TIME);
-    });
-
-    expect(result.current.endTime.value).not.toBe(CHANGE_TIME_AFTER_HOUR);
-  });
-
   it('선택한 끝 시간(endTime)이 시작 시간(startTime)보다 빠르다면 선택한 시간값으로 변경되지 않는다.', () => {
     const CHANGE_START_TIME = '04:00';
     const CHANGE_END_TIME = '01:00';

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
@@ -52,5 +52,5 @@ export function isTimeSelectable(startTime: string, endTime: string) {
 export function addHoursToCurrentTime(currentTime: string, hours: number) {
   const [currentHours, currentMinutes] = currentTime.split(':').map(Number);
 
-  return currentHours + hours + ':' + currentMinutes;
+  return currentHours + hours + ':' + String(currentMinutes).padStart(2, '0');
 }

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
@@ -52,5 +52,7 @@ export function isTimeSelectable(startTime: string, endTime: string) {
 export function addHoursToCurrentTime(currentTime: string, hours: number) {
   const [currentHours, currentMinutes] = currentTime.split(':').map(Number);
 
-  return currentHours + hours + ':' + String(currentMinutes).padStart(2, '0');
+  return (
+    String(currentHours + hours).padStart(2, '0') + ':' + String(currentMinutes).padStart(2, '0')
+  );
 }

--- a/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
+++ b/frontend/src/hooks/useTimeRangeDropdown/useTimeRangeDropdown.utils.ts
@@ -48,11 +48,9 @@ export function isTimeSelectable(startTime: string, endTime: string) {
   return true;
 }
 
-// 현재 시간에서 1시간 더한 시간을 반화해주는 함수(@낙타)
+// 현재 시간에서 1시간 더한 시간을 반환해주는 함수(@낙타)
 export function addHoursToCurrentTime(currentTime: string, hours: number) {
   const [currentHours, currentMinutes] = currentTime.split(':').map(Number);
 
-  return (
-    String(currentHours + hours).padStart(2, '0') + ':' + String(currentMinutes).padStart(2, '0')
-  );
+  return `${String(currentHours + hours).padStart(2, '0')}:${String(currentMinutes).padStart(2, '0')}`;
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #337 

## 작업 내용


https://github.com/user-attachments/assets/cb3503ee-307d-43ba-9a5e-8407dc7a687f


<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

useTimeRangeDropdown util 함수 수정

```tsx
export function addHoursToCurrentTime(currentTime: string, hours: number) {
  const [currentHours, currentMinutes] = currentTime.split(':').map(Number);

  return (
    String(currentHours + hours).padStart(2, '0') + ':' + String(currentMinutes).padStart(2, '0')
  );
}
```

해당 함수가 시간, 분을 반환할 때 숫자로 반환하기 때문에 한자리 숫자일 때 앞에 ‘0’을 붙이도록 수정했습니다.

이에 대한 테스트 케이스도 추가했어용

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
