### PR TITLE
[FE] 비밀번호 입력 간소화 및 모바일 숫자 키패드를 적용

### DIFF
--- a/frontend/src/constants/inputFields.ts
+++ b/frontend/src/constants/inputFields.ts
@@ -1,22 +1,11 @@
-export const INPUT_FIELD_RULES = {
-  meetingName: {
-    minLength: 1,
-    maxLength: 10,
-  },
-  nickname: {
-    minLength: 1,
-    maxLength: 5,
-  },
-  password: {
-    minLength: 1,
-    maxLength: 10,
-    pattern: /^[a-zA-Z0-9!@#$%]+$/,
-  },
+export const INPUT_FIELD_PATTERN = {
+  meetingName: /^.{1,10}$/, // 1~10자 사이의 모든 문자
+  nickname: /^.{1,5}$/, // 1~5자 사이의 모든 문자,
+  password: /^\d{4}$/, // 4자리 숫자
 };
 
 export const FIELD_DESCRIPTIONS = {
   meetingName: '약속 이름은 1~10자 사이로 입력해 주세요.',
-  nickname: '닉네임을 1~5자 사이로 입력해 주세요.',
-  password:
-    '비밀번호를 1~10자 사이로 입력해 주세요.\n사용 가능한 문자는 알파벳, 숫자, 특수문자(!@#$%)입니다.',
+  nickname: '닉네임은 1~5자 사이로 입력해 주세요.',
+  password: '비밀번호는 4자리 숫자로 입력해 주세요.',
 };

--- a/frontend/src/hooks/useInput/useInput.ts
+++ b/frontend/src/hooks/useInput/useInput.ts
@@ -2,9 +2,8 @@ import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 
 interface ValidationRules {
-  minLength?: number;
-  maxLength?: number;
   pattern?: RegExp;
+  errorMessage?: string;
 }
 
 const useInput = (rules?: ValidationRules) => {
@@ -14,17 +13,10 @@ const useInput = (rules?: ValidationRules) => {
   const getValidationError = (input: string) => {
     if (!rules) return null;
 
-    if (rules.minLength && input.length < rules.minLength) {
-      return `최소 ${rules.minLength}글자 이상이어야 합니다.`;
-    }
-
-    if (rules.maxLength && input.length > rules.maxLength) {
-      return `최대 ${rules.maxLength}글자까지 입력 가능합니다.`;
-    }
-
     if (rules.pattern && !rules.pattern.test(input)) {
-      return '올바른 형식이 아닙니다.';
+      return rules.errorMessage || '올바른 형식이 아닙니다.';
     }
+
     return null;
   };
 

--- a/frontend/src/pages/AttendeeLoginPage/index.tsx
+++ b/frontend/src/pages/AttendeeLoginPage/index.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 
-import PasswordInput from '@components/PasswordInput';
 import { Button } from '@components/_common/Buttons/Button';
 import Field from '@components/_common/Field';
 import Input from '@components/_common/Input';
@@ -9,7 +8,7 @@ import useInput from '@hooks/useInput/useInput';
 
 import { usePostLoginMutation } from '@stores/servers/user/mutations';
 
-import { FIELD_DESCRIPTIONS, INPUT_FIELD_RULES } from '@constants/inputFields';
+import { FIELD_DESCRIPTIONS, INPUT_FIELD_PATTERN } from '@constants/inputFields';
 
 import { s_container, s_inputContainer } from './AttendeeLoginPage.styles';
 
@@ -22,8 +21,8 @@ export default function AttendeeLoginPage() {
     onValueChange: handleAttendeeNameChange,
     errorMessage: attendeeNameErrorMessage,
   } = useInput({
-    minLength: INPUT_FIELD_RULES.nickname.minLength,
-    maxLength: INPUT_FIELD_RULES.nickname.maxLength,
+    pattern: INPUT_FIELD_PATTERN.nickname,
+    errorMessage: FIELD_DESCRIPTIONS.nickname,
   });
 
   const {
@@ -31,9 +30,8 @@ export default function AttendeeLoginPage() {
     onValueChange: handleAttendeePasswordChange,
     errorMessage: attendeePasswordErrorMessage,
   } = useInput({
-    minLength: INPUT_FIELD_RULES.password.minLength,
-    maxLength: INPUT_FIELD_RULES.password.maxLength,
-    pattern: INPUT_FIELD_RULES.password.pattern,
+    pattern: INPUT_FIELD_PATTERN.password,
+    errorMessage: FIELD_DESCRIPTIONS.password,
   });
 
   const isFormValid = () => {
@@ -79,7 +77,9 @@ export default function AttendeeLoginPage() {
         <Field>
           <Field.Label id="비밀번호" labelText="비밀번호" />
           <Field.Description description={FIELD_DESCRIPTIONS.password} />
-          <PasswordInput
+          <Input
+            type="number"
+            id="비밀번호"
             placeholder="비밀번호를 입력하세요."
             value={attendeePassword}
             onChange={handleAttendeePasswordChange}

--- a/frontend/src/pages/AttendeeLoginPage/index.tsx
+++ b/frontend/src/pages/AttendeeLoginPage/index.tsx
@@ -80,6 +80,8 @@ export default function AttendeeLoginPage() {
           <Input
             type="number"
             id="비밀번호"
+            inputMode="numeric"
+            pattern="[0-9]*"
             placeholder="비밀번호를 입력하세요."
             value={attendeePassword}
             onChange={handleAttendeePasswordChange}

--- a/frontend/src/pages/CreateMeetingPage/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/index.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 
-import PasswordInput from '@components/PasswordInput';
 import TimeRangeSelector from '@components/TimeRangeSelector';
 import { Button } from '@components/_common/Buttons/Button';
 import Calendar from '@components/_common/Calendar';
@@ -13,7 +12,7 @@ import useTimeRangeDropdown from '@hooks/useTimeRangeDropdown/useTimeRangeDropdo
 
 import { usePostMeetingMutation } from '@stores/servers/meeting/mutation';
 
-import { FIELD_DESCRIPTIONS, INPUT_FIELD_RULES } from '@constants/inputFields';
+import { FIELD_DESCRIPTIONS, INPUT_FIELD_PATTERN } from '@constants/inputFields';
 
 import { s_confirmContainer, s_formContainer } from './CreateMeetingPage.styles';
 
@@ -25,8 +24,8 @@ export default function CreateMeetingPage() {
     onValueChange: handleMeetingNameChange,
     errorMessage: meetingNameErrorMessage,
   } = useInput({
-    minLength: INPUT_FIELD_RULES.meetingName.minLength,
-    maxLength: INPUT_FIELD_RULES.meetingName.maxLength,
+    pattern: INPUT_FIELD_PATTERN.meetingName,
+    errorMessage: FIELD_DESCRIPTIONS.meetingName,
   });
 
   const {
@@ -34,8 +33,8 @@ export default function CreateMeetingPage() {
     onValueChange: handleHostNameChange,
     errorMessage: hostNameErrorMessage,
   } = useInput({
-    minLength: INPUT_FIELD_RULES.nickname.minLength,
-    maxLength: INPUT_FIELD_RULES.nickname.maxLength,
+    pattern: INPUT_FIELD_PATTERN.nickname,
+    errorMessage: FIELD_DESCRIPTIONS.nickname,
   });
 
   const {
@@ -43,9 +42,8 @@ export default function CreateMeetingPage() {
     onValueChange: handleHostPasswordChange,
     errorMessage: hostPasswordError,
   } = useInput({
-    minLength: INPUT_FIELD_RULES.password.minLength,
-    maxLength: INPUT_FIELD_RULES.password.maxLength,
-    pattern: INPUT_FIELD_RULES.password.pattern,
+    pattern: INPUT_FIELD_PATTERN.password,
+    errorMessage: FIELD_DESCRIPTIONS.password,
   });
 
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
@@ -114,7 +112,12 @@ export default function CreateMeetingPage() {
         <Field>
           <Field.Label id="비밀번호" labelText="비밀번호" />
           <Field.Description description={FIELD_DESCRIPTIONS.password} />
-          <PasswordInput id="비밀번호" value={hostPassword} onChange={handleHostPasswordChange} />
+          <Input
+            type="number"
+            id="비밀번호"
+            value={hostPassword}
+            onChange={handleHostPasswordChange}
+          />
           <Field.ErrorMessage errorMessage={hostPasswordError} />
         </Field>
 

--- a/frontend/src/pages/CreateMeetingPage/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/index.tsx
@@ -115,6 +115,8 @@ export default function CreateMeetingPage() {
           <Input
             type="number"
             id="비밀번호"
+            inputMode="numeric"
+            pattern="[0-9]*"
             value={hostPassword}
             onChange={handleHostPasswordChange}
           />


### PR DESCRIPTION
## 관련 이슈
- resolves: #339 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->
<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
### 1. 입력 필드 유효성 검사 규칙 개선 및 단순화
   - 각 필드(meetingName, nickname, password)의 유효성 검사 규칙을 정규표현식으로 단순화
   - 비밀번호 규칙을 4자리 숫자로 변경
   - 새로운 비밀번호 규칙(4자리 숫자)에 맞게 label 텍스트 수정

### 2. 모바일 숫자 키패드 적용
- input type="number" 적용
- iOS에서는 추가 속성 적용 (`inputMode="numeric"`과 `pattern="[0-9]*"` 속성을 추가하여 iOS 기기에서 숫자 전용 키패드가 표시되도록 개선)

## 참고 자료
[작업 현황 정리 노션 링크](https://paper-mass-5ff.notion.site/4f4d0d9cfde84d0cb17f2537b7815069?pvs=4)

## 특이 사항
<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->
비밀번호 입력이 4자리 숫자로 변경되고 모바일 키패드 입력이 도입됨에 따라 `PasswordInput 컴포넌트`(비밀번호 숨기기/표시 기능이 포함된 컴포넌트)는 현재 사용되지 않고 있습니다. 
그러나 추후에 필요할 수 있으므로 컴포넌트는 삭제하지 않고 남겨두었습니다.

## 리뷰 요구사항 (선택)
<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->
<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->
<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->