### PR TITLE
[BE] 비밀번호 검증 로직 변경

### DIFF
--- a/backend/src/main/java/kr/momo/domain/attendee/AttendeePassword.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/AttendeePassword.java
@@ -16,9 +16,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AttendeePassword {
 
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[a-zA-Z0-9!@*#$%]+$");
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile("^\\d{4}+$");
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 5)
     private String password;
 
     public AttendeePassword(String password) {
@@ -27,14 +27,7 @@ public class AttendeePassword {
     }
 
     private void validatePassword(String password) {
-        validatePasswordLength(password);
         validatePasswordFormat(password);
-    }
-
-    private void validatePasswordLength(String password) {
-        if (password.length() > 10) {
-            throw new MomoException(AttendeeErrorCode.INVALID_PASSWORD_LENGTH);
-        }
     }
 
     private void validatePasswordFormat(String password) {

--- a/backend/src/main/java/kr/momo/domain/attendee/AttendeePassword.java
+++ b/backend/src/main/java/kr/momo/domain/attendee/AttendeePassword.java
@@ -18,7 +18,7 @@ public class AttendeePassword {
 
     private static final Pattern PASSWORD_PATTERN = Pattern.compile("^\\d{4}+$");
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false, length = 4)
     private String password;
 
     public AttendeePassword(String password) {

--- a/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/AttendeeErrorCode.java
@@ -5,8 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum AttendeeErrorCode implements ErrorCodeType {
 
     INVALID_NAME_LENGTH(HttpStatus.BAD_REQUEST, "이름 길이는 최대 5글자까지 가능합니다."),
-    INVALID_PASSWORD_LENGTH(HttpStatus.BAD_REQUEST, "비밀번호 길이는 최대 10글자까지 가능합니다."),
-    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호 형식은 숫자, 문자, 특수문자만 가능합니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호 형식은 4자리 숫자입니다."),
     PASSWORD_MISMATCHED(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_ATTENDEE(HttpStatus.BAD_REQUEST, "해당 약속에 참여하는 참가자 정보가 없습니다."),
     NOT_FOUND_ATTENDEE(HttpStatus.NOT_FOUND, "해당 약속에 참여하는 참가자 정보가 없습니다."),

--- a/backend/src/main/java/kr/momo/service/attendee/dto/AttendeeLoginRequest.java
+++ b/backend/src/main/java/kr/momo/service/attendee/dto/AttendeeLoginRequest.java
@@ -15,8 +15,8 @@ public record AttendeeLoginRequest(
 
         @NotEmpty
         @Schema(description = "참가자 비밀번호", example = "1234")
-        @Length(max = 10, message = "비밀번호는 10자 이하입니다.")
-        @Pattern(regexp = "^[a-zA-Z0-9!@*#$%]+$", message = "비밀번호는 알파벳 대소문자와 숫자만 포함해야 합니다.")
+        @Length(max = 10, message = "비밀번호는 4자리 숫자입니다.")
+        @Pattern(regexp = "^\\d{4}+$", message = "비밀번호는 4자리 숫자여야 합니다.")
         String password
 ) {
 }

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -120,9 +120,10 @@ class MeetingControllerTest {
         LocalDate today = LocalDate.now();
         LocalDate tomorrow = today.plusDays(1);
         LocalDate dayAfterTomorrow = today.plusDays(2);
+        AttendeeFixture hostJazz = AttendeeFixture.HOST_JAZZ;
         MeetingCreateRequest request = new MeetingCreateRequest(
-                "host",
-                "momo",
+                hostJazz.getName(),
+                hostJazz.getPassword(),
                 "momoMeeting",
                 List.of(tomorrow.toString(), dayAfterTomorrow.toString()),
                 "08:00",

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -60,7 +60,7 @@ class ScheduleControllerTest {
     void setUp() {
         RestAssured.port = port;
         meeting = meetingRepository.save(MeetingFixture.MOVIE.create());
-        attendee = attendeeRepository.save(new Attendee(meeting, "name", "password", Role.GUEST));
+        attendee = attendeeRepository.save(new Attendee(meeting, "name", "1234", Role.GUEST));
         today = availableDateRepository.save(new AvailableDate(LocalDate.now(), meeting));
         tomorrow = availableDateRepository.save(new AvailableDate(LocalDate.now().plusDays(1), meeting));
     }

--- a/backend/src/test/java/kr/momo/domain/attendee/AttendeePasswordTest.java
+++ b/backend/src/test/java/kr/momo/domain/attendee/AttendeePasswordTest.java
@@ -10,26 +10,26 @@ import org.junit.jupiter.api.Test;
 
 class AttendeePasswordTest {
 
-    @DisplayName("참가자 비밀번호가 20글자를 초과하면 예외를 발생시킨다.")
+    @DisplayName("참가자 비밀번호가 4글자를 초과하면 예외를 발생시킨다.")
     @Test
     void throwsExceptionIfAttendeePasswordIsTooLong() {
         assertThatThrownBy(() -> new AttendeePassword("invalid_password_length_invalid_password_length"))
                 .isInstanceOf(MomoException.class)
-                .hasMessage(AttendeeErrorCode.INVALID_PASSWORD_LENGTH.message());
+                .hasMessage(AttendeeErrorCode.INVALID_PASSWORD_FORMAT.message());
     }
 
     @DisplayName("참가자 비밀번호 객체가 정상 생성된다.")
     @Test
     void createAttendeePasswordObjectSuccessfully() {
         assertThatNoException()
-                .isThrownBy(() -> new AttendeePassword("momo"));
+                .isThrownBy(() -> new AttendeePassword("1234"));
     }
 
     @DisplayName("비밀번호가 서로 다르면 예외를 발생시킨다.")
     @Test
     void throwsExceptionForMismatchedPasswords() {
         AttendeePassword password = new AttendeePassword("1234");
-        AttendeePassword other = new AttendeePassword("123456");
+        AttendeePassword other = new AttendeePassword("4321");
 
         assertThatThrownBy(() -> password.verifyPassword(other))
                 .isInstanceOf(MomoException.class)

--- a/backend/src/test/java/kr/momo/fixture/AttendeeFixture.java
+++ b/backend/src/test/java/kr/momo/fixture/AttendeeFixture.java
@@ -8,11 +8,11 @@ import kr.momo.domain.meeting.Meeting;
 
 public enum AttendeeFixture {
 
-    HOST_JAZZ("jazz", "hostPw!12", Role.HOST),
-    GUEST_DAON("daon", "daonPw!12", Role.GUEST),
-    GUEST_BAKEY("bakey", "bakeyPw!12", Role.GUEST),
-    GUEST_PEDRO("pedro", "pedroPw!12", Role.GUEST),
-    GUEST_MARK("mark", "mark!12", Role.GUEST);
+    HOST_JAZZ("jazz", "1234", Role.HOST),
+    GUEST_DAON("daon", "4321", Role.GUEST),
+    GUEST_BAKEY("bakey", "3422", Role.GUEST),
+    GUEST_PEDRO("pedro", "4353", Role.GUEST),
+    GUEST_MARK("mark", "1234", Role.GUEST);
 
     private final String name;
     private final String password;
@@ -26,5 +26,13 @@ public enum AttendeeFixture {
 
     public Attendee create(Meeting meeting) {
         return new Attendee(meeting, new AttendeeName(name), new AttendeePassword(password), role);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #341 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

비밀번호 검증 로직을 `특수번호를 포함한 10자리 문자,숫자` -> `4자리 숫자`로 변경했습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

**변경이유**
현재 모모는 “비밀번호를 1~10자 사이로 입력해 주세요. 사용 가능한 문자는 알파벳, 숫자, 특수문자(!@#$%)입니다.” 라고 적혀있습니다.
이 안내 문구로 인해 사용자들은 비밀번호를 길게 입력해야 한다고 생각하여, 긴 비밀번호를 입력하는 경향을 보였습니다.
때문에 비밀번호를 `4자리 숫자`로 제한하여 입력 과정을 단순화했습니다.

자세한 내용은 @Yoonkyoungme이 작성한 [해당 기능에 대한 문서](https://paper-mass-5ff.notion.site/4f4d0d9cfde84d0cb17f2537b7815069)를 참고해 주세요~

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
