### PR TITLE
[FE] CopyWebpackPlugin을 사용하여 favicon 적용 문제 해결

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "@typescript-eslint/eslint-plugin": "7.16.0",
         "@typescript-eslint/parser": "7.16.0",
         "babel-loader": "9.1.3",
+        "copy-webpack-plugin": "^12.0.2",
         "dotenv-webpack": "8.1.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-jsx-a11y": "6.9.0",
@@ -9298,6 +9299,74 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
+    "node_modules/copy-webpack-plugin": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz",
+      "integrity": "sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.1",
+        "globby": "^14.0.0",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.2.0",
+        "serialize-javascript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/globby": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-webpack-plugin/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.37.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
@@ -12065,7 +12134,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "@typescript-eslint/eslint-plugin": "7.16.0",
     "@typescript-eslint/parser": "7.16.0",
     "babel-loader": "9.1.3",
+    "copy-webpack-plugin": "^12.0.2",
     "dotenv-webpack": "8.1.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-jsx-a11y": "6.9.0",

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,10 +1,12 @@
 const path = require('path');
+const webpack = require('webpack');
+
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const DotenvWebpackPlugin = require('dotenv-webpack');
 
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
-const webpack = require('webpack');
 
 module.exports = () => ({
   entry: './src/index.tsx',
@@ -68,6 +70,9 @@ module.exports = () => ({
     }),
     new HtmlWebpackPlugin({
       template: 'public/index.html',
+    }),
+    new CopyWebpackPlugin({
+      patterns: [{ from: 'public/assets/favicons', to: 'assets/favicons' }],
     }),
     new ForkTsCheckerWebpackPlugin(),
     new DotenvWebpackPlugin(),


### PR DESCRIPTION
## 관련 이슈
- resolves: #347 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->
<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

### 문제 상황
Webpack은 기본적으로 src 디렉토리의 파일만 처리하므로, public 디렉토리에 있는 favicon 파일들은 처리 대상에서 제외됩니다.
그 결과, 빌드된 HTML 파일에서 favicon 파일의 경로가 올바르지 않게 설정되어 해당 파일을 불러올 수 없는 오류가 발생합니다.
아래 사진처럼 [배포된 사이트](https://www.momonow.kr/)에서 favicon이 적용되지 않는 문제가 발생하였습니다.
<img width="395" alt="image" src="https://github.com/user-attachments/assets/94a44ebb-db02-4a37-9290-ec38b62cdd72">

### 해결 방법
#### [CopyWebpackPlugin](https://webpack.js.org/plugins/copy-webpack-plugin/) 사용

여러 favicon 파일을 처리해야 하므로, [`CopyWebpackPlugin`](https://webpack.js.org/plugins/copy-webpack-plugin/)을 사용하여 모든 favicon 파일을 빌드 디렉토리로 복사하도록 설정했습니다. 

```bash
npm install copy-webpack-plugin --save-dev
```

```jsx
const CopyWebpackPlugin = require('copy-webpack-plugin');

// plugins 배열에 추가
new CopyWebpackPlugin({
  patterns: [
    { from: 'public/assets/favicons', to: 'assets/favicons' }
  ],
})

```

### 결과

`build` 디렉토리의 파일을 S3에 수동으로 배포하여 테스트해보았습니다.
배포된 사이트에서 아래의 이미지와 같이 favicon이 잘 표시되는 것을 확인하였습니다.👏
<img width="393" alt="image" src="https://github.com/user-attachments/assets/34d6a455-54b5-41c4-a15f-49ebd14563f1">
<img width="149" alt="image" src="https://github.com/user-attachments/assets/46a051e8-f9d8-4ad8-8ebf-ba7fd506ebdd">

## 참고 자료
자세한 내용은 [작업 현황 정리 노션](https://paper-mass-5ff.notion.site/favicon-7bd8b6f2114e4b25bacb8237af42f82c?pvs=4)을 참고해 주세요. :)

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
