### PR TITLE
[BE] DB read, write 쿼리 트래픽을 분리해요

### DIFF
--- a/backend/src/main/java/kr/momo/config/DataSourceConfig.java
+++ b/backend/src/main/java/kr/momo/config/DataSourceConfig.java
@@ -1,0 +1,57 @@
+package kr.momo.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+@Profile("prod")
+public class DataSourceConfig {
+
+    public static final String SOURCE_SERVER = "source";
+    public static final String REPLICA_SERVER = "replica";
+
+    @Bean(SOURCE_SERVER)
+    @ConfigurationProperties(prefix = "spring.datasource.source")
+    public DataSource sourceDataSource() {
+        return DataSourceBuilder.create()
+                .build();
+    }
+
+    @Bean(REPLICA_SERVER)
+    @ConfigurationProperties(prefix = "spring.datasource.replica")
+    public DataSource replicaDataSource() {
+        return DataSourceBuilder.create()
+                .build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier(SOURCE_SERVER) DataSource source,
+            @Qualifier(REPLICA_SERVER) DataSource replica
+    ) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(SOURCE_SERVER, source);
+        dataSourceMap.put(REPLICA_SERVER, replica);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(source);
+        return routingDataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        DataSource dataSource = routingDataSource(sourceDataSource(), replicaDataSource());
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+}

--- a/backend/src/main/java/kr/momo/config/DataSourceConfig.java
+++ b/backend/src/main/java/kr/momo/config/DataSourceConfig.java
@@ -1,6 +1,5 @@
 package kr.momo.config;
 
-import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,10 +38,10 @@ public class DataSourceConfig {
             @Qualifier(REPLICA_SERVER) DataSource replica
     ) {
         RoutingDataSource routingDataSource = new RoutingDataSource();
-        Map<Object, Object> dataSourceMap = new HashMap<>();
-        dataSourceMap.put(SOURCE_SERVER, source);
-        dataSourceMap.put(REPLICA_SERVER, replica);
-
+        Map<Object, Object> dataSourceMap = Map.of(
+                SOURCE_SERVER, source,
+                REPLICA_SERVER, replica
+        );
         routingDataSource.setTargetDataSources(dataSourceMap);
         routingDataSource.setDefaultTargetDataSource(source);
         return routingDataSource;

--- a/backend/src/main/java/kr/momo/config/RoutingDataSource.java
+++ b/backend/src/main/java/kr/momo/config/RoutingDataSource.java
@@ -1,0 +1,15 @@
+package kr.momo.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return DataSourceConfig.REPLICA_SERVER;
+        }
+        return DataSourceConfig.SOURCE_SERVER;
+    }
+}

--- a/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
+++ b/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
@@ -49,6 +49,7 @@ public class AttendeeService {
         return AttendeeLoginResponse.from(jwtManager.generate(attendee.getId()), attendee);
     }
 
+    @Transactional(readOnly = true)
     public List<String> findAll(String uuid) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));


### PR DESCRIPTION
## 관련 이슈

- resolves: #357 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
DB 트래픽을 rds로 변경하라는 요구사항을 반영하기 위해 읽기, 쓰기 쿼리별로 트래픽을 분리하였습니다

### `AbstractRoutingDatasource`
현재 컨텍스트에 따라 처리할 datasource를 동적으로 결정해도록 하는 Spring의 추상 클래스입니다.
RountingTable 형태로 datasource를 관리하며 `RoutingDataSource` 객체에 구현하여 datasource 결정 조건을 정해주었습니다.
datasource는 `@Transactional` readOnly 설정이 걸려있는 경우 replica datasource에 해당하는 key를 할당하도록 설정해주었습니다.

### `LazyConnectionDataSourceProxy`
스프링의 기본 구현은 트랜잭션 시작시 커넥션을 확보하기 위해 DataSource를 결정 짓기 위해 연결합니다.

`LazyConnectionDataSourceProxy` 객체의 경우 DataSource 연결을 지연 로딩하여 필요할때만 연결을 생성합니다.

`RoutingDataSource`의 키 결정 조건인`TransactionSynchronizationManager.isCurrentTransactionReadOnly()`는 트랜잭션이 시작된 이후에 알 수 있기에 `LazyConnectionDataSourceProxy`를 사용하였습니다.

### 참고 
[Baeldung - A Guide to Spring AbstractRoutingDatasource](https://www.baeldung.com/spring-abstract-routing-data-source)
[Spring Docs - LazyConnectionDataSourceProxy](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/datasource/LazyConnectionDataSourceProxy.html)
 
## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

- 🚨 서브 모듈이 변경되었으니 확인 부탁드립니다
- 테스트 환경을 H2 DB 2대로 구축하려했으나 테스트 목적과 수정 범위가 방대하여 철회하였습니다. 대신 로컬에서 replica 적용한 DB 2대로 검증하였습니다
  - H2 는 물리적으로 replica를 적용할 수 없어 매번 동일한 2개의 데이터를 넣어줘야한다.
  - 모든 테스트 코드를 수정해야한다.
  - 궁금하신 분은 서브 모듈을 참고하여 로컬 yml 파일에 적용하시면 됩니다 
  - (Config 내 `@Profile` 변경도 필수)

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
