### PR TITLE
[BE] replica로 업데이트 쿼리 날아가던 오류 수정

### DIFF
--- a/backend/src/main/java/kr/momo/config/RoutingDataSource.java
+++ b/backend/src/main/java/kr/momo/config/RoutingDataSource.java
@@ -1,15 +1,19 @@
 package kr.momo.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 public class RoutingDataSource extends AbstractRoutingDataSource {
 
+    private static final Logger log = LoggerFactory.getLogger(RoutingDataSource.class);
+
     @Override
     protected Object determineCurrentLookupKey() {
-        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
-            return DataSourceConfig.REPLICA_SERVER;
-        }
-        return DataSourceConfig.SOURCE_SERVER;
+        boolean currentTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        String key = currentTransactionReadOnly ? DataSourceConfig.REPLICA_SERVER : DataSourceConfig.SOURCE_SERVER;
+        log.info("Activated Datasource: {}", key);
+        return key;
     }
 }

--- a/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
+++ b/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
@@ -67,6 +67,7 @@ public class AttendeeService {
     /**
      * TEMP: 비밀번호 마이그레이션 이후 삭제될 메서드입니다.
      */
+    @Transactional
     public Integer updateAllPassword() {
         List<Attendee> attendees = attendeeRepository.findAll();
         List<Attendee> rawAttendees = attendees.stream()


### PR DESCRIPTION
## 관련 이슈

- resolves: #373 
## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

`@Transactional`을 붙히지 않아 우선으로 날아간 select 쿼리로 인해 replica로 datasource가 설정된 상태에서 update 쿼리가 날아가 에러가 발생했어요.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
