### PR TITLE
[FE] 달력 테스트 코드 작성

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -9,4 +9,9 @@ module.exports = {
   },
   setupFiles: ['./jest.polyfills.js'],
   reporters: ['default', ['jest-junit', { outputDirectory: 'reports', outputName: 'report.xml' }]],
+
+  moduleNameMapper: {
+    '^@utils/(.*)$': '<rootDir>/src/utils/$1',
+    '^@constants/(.*)$': '<rootDir>/src/constants/$1',
+  },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "build:dev": "NODE_ENV=production USE_BUNDLE_ANALYZER=false webpack --config webpack.prod.js",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject ./dist && sentry-cli sourcemaps upload -o momo2024 -p momo-harry-test /dist",
     "lint:css": "stylelint '**/*.styles.ts' --fix",
-    "test": "jest --watch",
+    "test": "jest",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "build:dev": "NODE_ENV=production USE_BUNDLE_ANALYZER=false webpack --config webpack.prod.js",
     "sentry:sourcemaps": "sentry-cli sourcemaps inject ./dist && sentry-cli sourcemaps upload -o momo2024 -p momo-harry-test /dist",
     "lint:css": "stylelint '**/*.styles.ts' --fix",
-    "test": "jest",
+    "test": "jest --watch",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/frontend/src/hooks/useCalendar/useCalendar.test.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.test.ts
@@ -36,7 +36,7 @@ describe('useCalendar', () => {
   });
 
   describe('달력 년도 이동 기능', () => {
-    it('다음 년도로 이동하면, 년도가 변경되어야 한다.', async () => {
+    it('12월에서 다음 달로 이동하면 다음 년도로 변경되어야 한다.', () => {
       jest.setSystemTime(new Date(TEST_YEAR, LAST_MONTH_INDEX, TEST_DATE));
 
       const { result } = renderHook(() => useCalendar());
@@ -55,7 +55,7 @@ describe('useCalendar', () => {
       expect(isCurrentMonth).toBeFalsy();
     });
 
-    it('이전 년도 이동하면, 년도가 변경되어야 한다.', async () => {
+    it('1월에서 이전 년도로 이동하면 이전 년도로 변경되어야 한다.', () => {
       jest.setSystemTime(new Date(TEST_YEAR, FIRST_MONTH_INDEX, TEST_DATE));
 
       const { result } = renderHook(() => useCalendar());

--- a/frontend/src/hooks/useCalendar/useCalendar.test.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.test.ts
@@ -1,0 +1,175 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+
+import { getFullDate } from '@utils/date';
+
+import useCalendar from './useCalendar';
+
+describe('useCalendar', () => {
+  const TEST_YEAR = 2024;
+  const TEST_MONTH = 9;
+  const TEST_DATE = 4;
+  const FIRST_MONTH_INDEX = 0;
+  const LAST_MONTH_INDEX = 11;
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe('현재 달력 데이터 계산', () => {
+    it('현재 년도, 월을 올바르게 계산해서 반환한다.', () => {
+      jest.setSystemTime(new Date(TEST_YEAR, TEST_MONTH, TEST_DATE));
+
+      const { result } = renderHook(() => useCalendar());
+
+      const { headers, isCurrentMonth } = result.current;
+      const { currentYear, currentMonth } = headers;
+
+      expect(currentYear).toBe(TEST_YEAR);
+      expect(currentMonth).toBe(TEST_MONTH);
+      expect(isCurrentMonth).toBeTruthy();
+    });
+  });
+
+  describe('달력 년도 이동 기능', () => {
+    it('다음 년도로 이동하면, 년도가 변경되어야 한다.', async () => {
+      jest.setSystemTime(new Date(TEST_YEAR, LAST_MONTH_INDEX, TEST_DATE));
+
+      const { result } = renderHook(() => useCalendar());
+      const { view } = result.current;
+      const { moveToNextMonth } = view;
+
+      act(() => {
+        moveToNextMonth();
+      });
+
+      const { headers, isCurrentMonth } = result.current;
+      const { currentYear, currentMonth } = headers;
+
+      expect(currentYear).toBe(TEST_YEAR + 1);
+      expect(currentMonth).toBe(FIRST_MONTH_INDEX);
+      expect(isCurrentMonth).toBeFalsy();
+    });
+
+    it('이전 년도 이동하면, 년도가 변경되어야 한다.', async () => {
+      jest.setSystemTime(new Date(TEST_YEAR, FIRST_MONTH_INDEX, TEST_DATE));
+
+      const { result } = renderHook(() => useCalendar());
+      const { view } = result.current;
+      const { moveToPrevMonth } = view;
+
+      act(() => {
+        moveToPrevMonth();
+      });
+
+      const { headers, isCurrentMonth } = result.current;
+      const { currentYear, currentMonth } = headers;
+
+      expect(currentYear).toBe(TEST_YEAR - 1);
+      expect(currentMonth).toBe(LAST_MONTH_INDEX);
+      expect(isCurrentMonth).toBeFalsy();
+    });
+  });
+
+  describe('달력 월 이동 기능', () => {
+    it('이전 달로 이동하면, 달 데이터가 변경되어야 한다.', () => {
+      jest.setSystemTime(new Date(TEST_YEAR, TEST_MONTH, TEST_DATE));
+
+      const { result } = renderHook(() => useCalendar());
+      const { view } = result.current;
+      const { moveToPrevMonth } = view;
+
+      act(() => {
+        moveToPrevMonth();
+      });
+
+      const { headers, isCurrentMonth } = result.current;
+      const { currentYear, currentMonth } = headers;
+
+      expect(currentYear).toBe(TEST_YEAR);
+      expect(currentMonth).toBe(TEST_MONTH - 1);
+      expect(isCurrentMonth).toBeFalsy();
+    });
+
+    it('다음 달로 이동하면 달 데이터가 변경되어야 한다..', () => {
+      jest.setSystemTime(new Date(TEST_YEAR, TEST_MONTH, TEST_DATE));
+
+      const { result } = renderHook(() => useCalendar());
+      const { view } = result.current;
+      const { moveToNextMonth } = view;
+
+      act(() => {
+        moveToNextMonth();
+      });
+
+      const { headers, isCurrentMonth } = result.current;
+      const { currentYear, currentMonth } = headers;
+
+      expect(currentYear).toBe(TEST_YEAR);
+      expect(currentMonth).toBe(TEST_MONTH + 1);
+      expect(isCurrentMonth).toBeFalsy();
+    });
+  });
+
+  describe('월 이동 시, 변경된 달력 데이터 계산', () => {
+    it('현재 달의 마지막 주에 있는 current 상태의 날짜들이 다음 달로 이동했을 때 prev 상태로 변경되어야 한다.', () => {
+      const { result } = renderHook(() => useCalendar());
+      const {
+        body: { value: initialCalendarData },
+        view: { moveToNextMonth },
+      } = result.current;
+      const lastWeekOfCurrentMonth = initialCalendarData[initialCalendarData.length - 1].value;
+      const currentDatesInLastWeek = lastWeekOfCurrentMonth.filter(
+        (day) => day.status === 'current',
+      );
+
+      act(() => {
+        moveToNextMonth();
+      });
+
+      const {
+        body: { value: updatedCalendarData },
+      } = result.current;
+      const firstWeekOfNextMonth = updatedCalendarData[0].value;
+      const prevDatesInFirstWeek = firstWeekOfNextMonth.filter((day) => day.status === 'prev');
+
+      expect(prevDatesInFirstWeek.length).toBe(currentDatesInLastWeek.length);
+      currentDatesInLastWeek.forEach((date, index) => {
+        expect(getFullDate(prevDatesInFirstWeek[index].value)).toBe(getFullDate(date.value));
+        expect(prevDatesInFirstWeek[index].status).toBe('prev');
+      });
+    });
+
+    it('현재 달의 첫 주에 있는 current 상태의 날짜들이 이전 달로 이동했을 때 next 상태로 변경되어야 한다.', () => {
+      const { result } = renderHook(() => useCalendar());
+      const {
+        body: { value: initialCalendarData },
+        view: { moveToPrevMonth },
+      } = result.current;
+      const firstWeekOfCurrentMonth = initialCalendarData[0].value;
+      const currentDatesInFirstWeek = firstWeekOfCurrentMonth.filter(
+        (day) => day.status === 'current',
+      );
+
+      act(() => {
+        moveToPrevMonth();
+      });
+
+      const {
+        body: { value: updatedCalendarData },
+      } = result.current;
+      const lastWeekOfPrevMonth = updatedCalendarData[updatedCalendarData.length - 1].value;
+      const nextDatesInLastWeek = lastWeekOfPrevMonth.filter((day) => day.status === 'next');
+
+      expect(nextDatesInLastWeek.length).toBe(currentDatesInFirstWeek.length);
+      currentDatesInFirstWeek.forEach((date, index) => {
+        expect(getFullDate(nextDatesInLastWeek[index].value)).toBe(getFullDate(date.value));
+        expect(nextDatesInLastWeek[index].status).toBe('next');
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/useCalendar/useCalendar.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.ts
@@ -3,7 +3,7 @@ import type { MonthlyDays } from 'types/calendar';
 
 import { getMonth, getYear } from '@utils/date';
 
-import { getMonthlyDate } from './useCalendar.utils';
+import { getMonthlyCalendarDate } from './useCalendar.utils';
 
 interface useCalendarReturn {
   headers: {
@@ -39,7 +39,7 @@ const useCalendar = (): useCalendarReturn => {
     setCurrentFullDate(new Date(currentYear, currentMonth + 1));
   };
 
-  const monthlyDates = getMonthlyDate(currentFullDate);
+  const monthlyCalendarDate = getMonthlyCalendarDate(currentFullDate);
 
   return {
     headers: {
@@ -49,7 +49,7 @@ const useCalendar = (): useCalendarReturn => {
     },
     body: {
       today: TODAY,
-      value: monthlyDates,
+      value: monthlyCalendarDate,
     },
     view: {
       moveToNextMonth,

--- a/frontend/src/hooks/useCalendar/useCalendar.utils.test.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.utils.test.ts
@@ -1,0 +1,190 @@
+import { getDate, getDay, getFullDate, getMonth, getYear } from '@utils/date';
+
+import CALENDAR_PROPERTIES from '@constants/calendar';
+
+import {
+  getCalendarStartDate,
+  getDaysInMonth,
+  getMonthlyCalendarDate,
+  getMonthlyStartIndex,
+  getNumberOfWeeks,
+  getWeeklyDate,
+  setFirstDate,
+} from './useCalendar.utils';
+
+describe('Calendar utils', () => {
+  const TEST_YEAR = 2024;
+  const TEST_MONTH = 9;
+  const TEST_DATE = 4;
+  const TUESDAY_INDEX = 5;
+  const TEST_FULL_DATE = '2024-10-04';
+  const testDate = new Date(TEST_YEAR, TEST_MONTH, TEST_DATE);
+
+  describe('Calendar Base util functions test', () => {
+    it('getYear 함수는 올바른 년도를 반환한다.', () => {
+      const year = getYear(testDate);
+      expect(year).toBe(TEST_YEAR);
+    });
+
+    it('getMonth 함수는 현재 달에서 1을 뺀 값을 반환한다.', () => {
+      const month = getMonth(testDate);
+      expect(month).toBe(TEST_MONTH);
+    });
+
+    it('getDay 함수는 오늘 요일에 맞는 인덱스를 반환한다.', () => {
+      const day = getDay(testDate);
+      expect(day).toBe(TUESDAY_INDEX);
+    });
+
+    it('getDate 함수는 오늘 날짜를 반환한다.', () => {
+      const date = getDate(testDate);
+      expect(date).toBe(TEST_DATE);
+    });
+
+    it('getFullDate 함수는 오늘 날짜 정보를 문자열로 반환한다.', () => {
+      const fullDate = getFullDate(testDate);
+      expect(fullDate).toBe(TEST_FULL_DATE);
+    });
+  });
+
+  describe('serFirstDate', () => {
+    it('날짜 객체를 해당 달의 첫 번째 날짜로 변경한다.', () => {
+      const result = setFirstDate(testDate);
+      expect(getDate(result)).not.toBe(TEST_DATE);
+      expect(getDate(result)).toBe(1);
+    });
+  });
+
+  describe('getNumberOfWeeks', () => {
+    it('해당 달이 총 몇 주로 구성되는지 계산해서 반환한다.', () => {
+      const EXPECTED_NUMBER_OF_WEEKS = 5;
+      const numberOfWeeksInTestDate = getNumberOfWeeks(testDate);
+      expect(numberOfWeeksInTestDate).toBe(EXPECTED_NUMBER_OF_WEEKS);
+    });
+  });
+
+  describe('getDaysInMonth', () => {
+    it('해당 달의 전체 총 일수를 계산해서 반환한다.', () => {
+      const EXPECTED_DAYS_IN_MONTH = 31;
+      const dayInTestDate = getDaysInMonth(testDate);
+      expect(dayInTestDate).toBe(EXPECTED_DAYS_IN_MONTH);
+    });
+  });
+
+  describe('getCalendarStartDate', () => {
+    it('달력을 그리기 위한 첫 번째 날짜를 계산해서 반환한다.', () => {
+      const EXPECTED_CALENDAR_START_DATE = 29;
+      const EXPECTED_CALENDAR_START_FULL_DATE = '2024-09-29';
+      const calendarStartDate = getCalendarStartDate(testDate);
+
+      expect(getYear(calendarStartDate)).toBe(TEST_YEAR);
+      expect(getMonth(calendarStartDate)).toBe(TEST_MONTH - 1);
+      expect(getDate(calendarStartDate)).toBe(EXPECTED_CALENDAR_START_DATE);
+      expect(getFullDate(calendarStartDate)).toBe(EXPECTED_CALENDAR_START_FULL_DATE);
+    });
+  });
+
+  describe('getWeeklyDate', () => {
+    it('한 주 데이터에 이전 달이 포함되어 있으면, 해당 날짜의 상태는 prev여야 한다.', () => {
+      const calendarStartDate = getCalendarStartDate(testDate);
+
+      const firstWeeklyDate = getWeeklyDate(calendarStartDate, getMonth(testDate));
+      const { status } =
+        firstWeeklyDate.find(({ value }) => getMonth(value) === getMonth(testDate) - 1) ?? {};
+
+      expect(firstWeeklyDate).toHaveLength(CALENDAR_PROPERTIES.daysInOneWeek);
+      expect(status).toBe('prev');
+    });
+
+    it('한 주 데이터에 다음 달이 포함되어 있으면, 해당 날짜의 상태는 next여야 한다.', () => {
+      const numberOfWeeks = getNumberOfWeeks(testDate);
+      const calendarStartDate = getCalendarStartDate(testDate);
+      calendarStartDate.setDate(
+        getDate(calendarStartDate) + CALENDAR_PROPERTIES.daysInOneWeek * numberOfWeeks - 1,
+      );
+
+      const lastWeeklyDate = getWeeklyDate(calendarStartDate, getMonth(testDate));
+      const { status } =
+        lastWeeklyDate.find(({ value }) => getMonth(value) === getMonth(testDate) + 1) ?? {};
+
+      expect(lastWeeklyDate).toHaveLength(CALENDAR_PROPERTIES.daysInOneWeek);
+      expect(status).toBe('next');
+    });
+
+    it('한 주 데이터에 현재 달이 포함되어 있으면, 해당 날짜의 상태는 current여야 한다.', () => {
+      const calendarStartDate = getCalendarStartDate(testDate);
+      const firstWeeklyDate = getWeeklyDate(calendarStartDate, getMonth(testDate));
+
+      const { status } =
+        firstWeeklyDate.find(({ value }) => getMonth(value) === getMonth(testDate)) ?? {};
+
+      expect(status).toBe('current');
+    });
+  });
+
+  describe('getMonthlyCalendarDate', () => {
+    const EXPECTED_NUMBER_OF_WEEKS = 5;
+    const monthlyCalendarDate = getMonthlyCalendarDate(testDate);
+
+    it('한 달의 달력 데이터는 해당 달의 총 주 수와 일치해야 한다.', () => {
+      expect(monthlyCalendarDate).toHaveLength(EXPECTED_NUMBER_OF_WEEKS);
+    });
+
+    it('달력 데이터에서 이전 달의 날짜 개수가 올바른지 확인한다.', () => {
+      const prevMonthDates = monthlyCalendarDate
+        .flatMap((week) => week.value)
+        .filter((day) => day.status === 'prev');
+      const EXPECTED_PREV_MONTH_DAYS = getMonthlyStartIndex(testDate);
+
+      expect(prevMonthDates).toHaveLength(EXPECTED_PREV_MONTH_DAYS);
+    });
+
+    it('달력 데이터에서 다음 달의 날짜 개수가 올바른지 확인한다.', () => {
+      const numberOfWeeks = getNumberOfWeeks(testDate);
+      const totalDays = CALENDAR_PROPERTIES.daysInOneWeek * numberOfWeeks;
+      const daysInMonth = getDaysInMonth(testDate);
+      const nextMonthDates = monthlyCalendarDate
+        .flatMap((week) => week.value)
+        .filter((day) => day.status === 'next');
+
+      const PREV_MONTH_DAYS = getMonthlyStartIndex(testDate);
+      const EXPECTED_NEXT_MONTH_DAYS = totalDays - PREV_MONTH_DAYS - daysInMonth;
+
+      expect(nextMonthDates).toHaveLength(EXPECTED_NEXT_MONTH_DAYS);
+    });
+
+    it('달력 데이터에서 현재 달의 모든 날짜는 current 상태여야 한다.', () => {
+      monthlyCalendarDate.forEach((week) => {
+        week.value.forEach((day) => {
+          if (getMonth(day.value) === getMonth(testDate)) {
+            expect(day.status).toBe('current');
+          }
+        });
+      });
+    });
+
+    it('달력 데이터의 첫 번째 "current" 상태 이전의 모든 날짜는 "prev" 상태여야 한다.', () => {
+      const flattenedCalendarDates = monthlyCalendarDate.flatMap((week) => week.value);
+      const firstCurrentStatusDateIndex = flattenedCalendarDates.findIndex(
+        (day) => day.status === 'current',
+      );
+
+      Array.from({ length: firstCurrentStatusDateIndex }, (_, index) => {
+        expect(flattenedCalendarDates[index].status).toBe('prev');
+      });
+    });
+
+    it('달력 데이터의 마지막 "current" 상태 이후의 모든 날짜는 "prev" 상태여야 한다.', () => {
+      const reversedFlattenedCalendarDates = monthlyCalendarDate
+        .flatMap((week) => week.value)
+        .reverse();
+      const firstCurrentStatusDateIndex = reversedFlattenedCalendarDates.findIndex(
+        (day) => day.status === 'current',
+      );
+
+      Array.from({ length: firstCurrentStatusDateIndex }, (_, index) => {
+        expect(reversedFlattenedCalendarDates[index].status).toBe('next');
+      });
+    });
+  });
+});

--- a/frontend/src/hooks/useCalendar/useCalendar.utils.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.utils.ts
@@ -55,57 +55,20 @@ export const getWeeklyDate = (startDate: Date, currentMonthIndex: number): DateI
     };
   });
 
-/**
- * 주어진 날짜를 기준으로 해당 월의 달력 데이터를 계산하여 반환.
- * 이 함수는 해당 월이 몇 주에 걸쳐 있는지 계산하고, 주마다 날짜 정보를 생성하여 반환.
- * 월의 첫 번째 주와 마지막 주가 이전 달 또는 다음 달의 날짜로 채워질 수 있다.
- * 이렇게 한 이유는 현재 모모 서비스에서는, 이전 달 또는 다음 달의 데이터를 활용하고 있지 않지만 요구 사항이 변경되어 필요하게 되면 필요에 따라 유연하게 뽑아서 사용할 수 있도록 하기 위해서이다.
- *
- * @param {Date} date - 해당 월을 나타내는 JavaScript `Date` 객체. (해당 월의 아무 날짜나 가능합니다)
- *
- * @returns {MonthlyDays} 해당 월의 주 단위 데이터를 포함하는 배열을 반환합니다. 각 주는 객체로 표현된다. 아래는 객체에 대한 설명.
- *  - `key`: 해당 주의 고유 식별자.
- *  - `value`: `DateInfo` 객체 배열로, 각 날짜의 정보를 포함.
- *    - `key`: 특정 날짜를 나타내는 문자열 (예: `${date}` 형태).
- *    - `value`: 해당 날짜의 `Date` 객체.
- *    - `status`: 해당 날짜가 'prevMonth' (이전 달), 'currentMonth' (현재 달), 'nextMonth' (다음 달) 중 어디에 속하는지 나타내는 값.
- *
- * 함수 실행 과정:
- * 1. `getNumberOfWeeks` 함수를 사용하여 해당 월이 몇 주에 걸쳐 있는지 계산합니다.
- * 2. `getMonthlyStartIndex` 함수를 사용하여 해당 월의 첫 번째 주에 이전 달의 날짜가 필요한지 계산합니다.
- * 3. `getWeeklyDate` 함수를 사용하여 주별로 날짜 데이터를 생성하며, 각 날짜가 현재 달, 이전 달, 또는 다음 달에 속하는지 판단하여 `status` 값을 설정합니다.
- *
- * 반환 데이터 예시:
- * [
- *   {
- *     key: 2023090, // 2023-09의 첫 번째 주
- *     value: [
- *       { key: '2023-08-27', value: Date, status: 'prevMonth' }, 이전 달 데이터인 8월 데이터가 포함되고, prevMonth 상태를 가짐.
- *       { key: '2023-08-28', value: Date, status: 'prevMonth' },
- *       ...
- *       { key: '2023-09-03', value: Date, status: 'currentMonth' }
- *     ]
- *   },
- *   ...
- *   {
- *     key: 2023094,
- *     value: [
- *       { key: '2023-09-25', value: Date, status: 'currentMonth' },
- *       { key: '2023-09-26', value: Date, status: 'currentMonth' },
- *       ...
- *       { key: '2023-10-01', value: Date, status: 'nextMonth' } // 다음 달 데이터인 10월 데이터가 포함되고, nextMonth 상태를 가짐.
- *     ]
- *   }
- * ]
- */
-export const getMonthlyDate = (date: Date): MonthlyDays => {
+export const getCalendarStartDate = (date: Date) => {
+  const monthStartDate = setFirstDate(date);
+  monthStartDate.setDate(1 - getMonthlyStartIndex(date));
+
+  return monthStartDate;
+};
+
+export const getMonthlyCalendarDate = (date: Date): MonthlyDays => {
   const numberOfWeeks = getNumberOfWeeks(date);
-  const monthlyStartDate = setFirstDate(new Date(date));
-  monthlyStartDate.setDate(1 - getMonthlyStartIndex(date));
+  const monthStartDate = getCalendarStartDate(date);
 
   return Array.from({ length: numberOfWeeks }, (_, i) => {
-    const newDate = new Date(monthlyStartDate);
-    newDate.setDate(getDate(monthlyStartDate) + CALENDAR_PROPERTIES.daysInOneWeek * i);
+    const newDate = new Date(monthStartDate);
+    newDate.setDate(getDate(monthStartDate) + CALENDAR_PROPERTIES.daysInOneWeek * i);
 
     return {
       key: getYear(date) * getMonth(date) + i,

--- a/frontend/src/hooks/useCalendar/useCalendar.utils.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.utils.ts
@@ -18,17 +18,17 @@ export const getDaysInMonth = (date: Date) => {
 };
 
 export const getNumberOfWeeks = (date: Date) => {
-  const firstOfMonth = setFirstDate(date);
+  const firstDateOfMonth = setFirstDate(date);
   const daysInMonth = getDaysInMonth(date);
-  const dayOfWeek = getDay(firstOfMonth);
+  const dayOfWeek = getDay(firstDateOfMonth);
 
   return Math.ceil((daysInMonth + dayOfWeek) / 7);
 };
 
 export const getMonthlyStartIndex = (date: Date) => {
-  const firstOfMonth = setFirstDate(date);
+  const firstDateOfMonth = setFirstDate(date);
 
-  return firstOfMonth.getDay();
+  return firstDateOfMonth.getDay();
 };
 
 const getMonthStatus = (targetDate: Date, currentMonthIndex: number): MonthStatus => {
@@ -56,19 +56,19 @@ export const getWeeklyDate = (startDate: Date, currentMonthIndex: number): DateI
   });
 
 export const getCalendarStartDate = (date: Date) => {
-  const monthStartDate = setFirstDate(date);
-  monthStartDate.setDate(1 - getMonthlyStartIndex(date));
+  const startDateOfMonth = setFirstDate(date);
+  startDateOfMonth.setDate(1 - getMonthlyStartIndex(date));
 
-  return monthStartDate;
+  return startDateOfMonth;
 };
 
 export const getMonthlyCalendarDate = (date: Date): MonthlyDays => {
   const numberOfWeeks = getNumberOfWeeks(date);
-  const monthStartDate = getCalendarStartDate(date);
+  const startDateOfCalendar = getCalendarStartDate(date);
 
   return Array.from({ length: numberOfWeeks }, (_, i) => {
-    const newDate = new Date(monthStartDate);
-    newDate.setDate(getDate(monthStartDate) + CALENDAR_PROPERTIES.daysInOneWeek * i);
+    const newDate = new Date(startDateOfCalendar);
+    newDate.setDate(getDate(startDateOfCalendar) + CALENDAR_PROPERTIES.daysInOneWeek * i);
 
     return {
       key: getYear(date) * getMonth(date) + i,


### PR DESCRIPTION
## 관련 이슈

- resolves: #382 
- jsDoc을 삭제하고 jest, RTL을 활용해서 달력 데이터 생성 로직에 대한 테스트 코드를 작성했습니다.

## 작업 내용

- 현재 달력 데이터를 생성하는 모듈은 이전 달, 다음 달 데이터를 함께 생성하게 됩니다.  
-> UI에서 이전 달, 다음 달 데이터를 활용할 수도 있기에 유연하게 해당 모듈을 사용하기 위해서 이 방식으로 구현했었습니다.
-> 현재 저희 서비스에서는 사용하고 있지는 않지만, 학습 겸 어떻게 더 달력 데이터를 유연하게 만들 수 있을까 하다가 이 방식을 떠올렸고 구현했습니다. 

### useCalendar.utils.test.ts

- 주, 월 별 달력 데이터를 올바르게 생성하는지 확인합니다.
- 생성된 달력 데이터들의 날짜가 올바른 상태(prev, current, next)를 가지는지 확인합니다.

### useCalender.test.ts

- 달력 데이터를 변경할 수 있는 책임을 가집니다.
- 이전 달, 다음 달로 이동했을 때 데이터가 이에 맞게 올바르게 변경되는지 테스트 합니다. 

## 특이 사항

달력 로직이 생각보다 복잡해서 시간이 많이 소요되었네요...원래는 스토리북도 더 직관적으로 확인할 수 있도록 날짜 상태에 따른 날짜 UI도 구분해서 UI 테스트를 진행하려고 했는데 이슈를 한 번 더 파야할 것 같아요! 테스트 초록불이 뜨니 안전한 달력을 만들었다는 느낌이 들어 안심이 되네요..ㅎ 

자바스크립트는 달(Month)의 인덱스를 0부터 시작해서 테스트 코드를 작성할 때 1씩 빼주고 테스트를 진행했습니다. UI영역에서 현재 달에 +1을 해준 것을 확인할 수 있는데, 0부터 시작하는 예외를 처리해주기 위함이었습니다! 리뷰하실 때, 참고바랍니다 🙏🙏🙏

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
