### PR TITLE
[BE] 비밀번호 마이그레이션 로직 삭제

### DIFF
--- a/backend/src/main/java/kr/momo/config/RoutingDataSource.java
+++ b/backend/src/main/java/kr/momo/config/RoutingDataSource.java
@@ -13,7 +13,7 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
     protected Object determineCurrentLookupKey() {
         boolean currentTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
         String key = currentTransactionReadOnly ? DataSourceConfig.REPLICA_SERVER : DataSourceConfig.SOURCE_SERVER;
-        log.info("Activated Datasource: {}", key);
+        log.debug("Activated Datasource: {}", key);
         return key;
     }
 }

--- a/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
+++ b/backend/src/main/java/kr/momo/controller/attendee/AttendeeController.java
@@ -50,12 +50,4 @@ public class AttendeeController implements AttendeeControllerDocs {
     public MomoApiResponse<List<String>> findAttendeesOfMeeting(@PathVariable String uuid) {
         return new MomoApiResponse<>(attendeeService.findAll(uuid));
     }
-
-    /**
-     * TEMP: 비밀번호 마이그레이션 이후 삭제될 메서드입니다.
-     */
-    @PostMapping("/api/v1/attendee/update-password")
-    public MomoApiResponse<Integer> updatePassword() {
-        return new MomoApiResponse<>(attendeeService.updateAllPassword());
-    }
 }

--- a/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
+++ b/backend/src/main/java/kr/momo/service/attendee/AttendeeService.java
@@ -63,24 +63,4 @@ public class AttendeeService {
                 .map(Attendee::name)
                 .toList();
     }
-
-    /**
-     * TEMP: 비밀번호 마이그레이션 이후 삭제될 메서드입니다.
-     */
-    @Transactional
-    public Integer updateAllPassword() {
-        List<Attendee> attendees = attendeeRepository.findAll();
-        List<Attendee> rawAttendees = attendees.stream()
-                .filter(attendee -> attendee.getPassword().getPassword().length() < 15)
-                .toList();
-        rawAttendees.forEach(
-                attendee -> {
-                    String rawPassword = attendee.getPassword().getPassword();
-                    String encodedPassword = passwordEncoder.encode(rawPassword);
-                    attendee.updatePassword(encodedPassword);
-                }
-        );
-        attendeeRepository.saveAll(rawAttendees);
-        return rawAttendees.size();
-    }
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #376 

## 작업 내용
### 평문화 비밀번호 마이그레이션 코드 삭제

비밀번호 마이그레이션을 완료하여 이젠 사용하지 않는 비밀번호 마이그레이션 코드를 삭제하였습니다.

### AbstractRoutingDataSource 내 로그 레벨 수정
현재 Datasource는 쿼리가 발생하는 시점에 Source DB와 Replica DB를 동적으로 선택하는데요.
이때 연결된 Datasource가 무엇인지 알고자 로그로 남겨두었는데요. 

`AbstractRoutingDataSource`가 스레드가 변경되어 데이터베이스 작업을 시작할 때마다 어떤 데이터소스를 사용할지 결정하기 위해 determineCurrentLookupKey()를 호출하게 되어 의도한 동작과 다를 때도 로그를 찍히는 것을 발견하게 되었습니다.
불필요하게 많아지는 로그를 방지하기 위해 debug 레벨로 로그를 남기도록 수정하였습니다 :)
