### PR TITLE
[BE] 약속 입장 조회 로직 추가

### DIFF
--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -8,7 +8,7 @@ import kr.momo.controller.auth.AuthAttendee;
 import kr.momo.service.meeting.MeetingConfirmService;
 import kr.momo.service.meeting.MeetingService;
 import kr.momo.service.meeting.dto.ConfirmedMeetingResponse;
-import kr.momo.service.meeting.dto.EntryMeetingResponse;
+import kr.momo.service.meeting.dto.MeetingHomeResponse;
 import kr.momo.service.meeting.dto.MeetingConfirmRequest;
 import kr.momo.service.meeting.dto.MeetingConfirmResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
@@ -75,8 +75,8 @@ public class MeetingController implements MeetingControllerDocs {
     }
 
     @GetMapping("/api/v1/meetings/{uuid}/home")
-    public MomoApiResponse<EntryMeetingResponse> findMeetingEntry(@PathVariable String uuid) {
-        EntryMeetingResponse response = meetingService.findMeetingHome(uuid);
+    public MomoApiResponse<MeetingHomeResponse> findMeetingEntry(@PathVariable String uuid) {
+        MeetingHomeResponse response = meetingService.findMeetingHome(uuid);
         return new MomoApiResponse<>(response);
     }
 

--- a/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
+++ b/backend/src/main/java/kr/momo/controller/meeting/MeetingController.java
@@ -8,6 +8,7 @@ import kr.momo.controller.auth.AuthAttendee;
 import kr.momo.service.meeting.MeetingConfirmService;
 import kr.momo.service.meeting.MeetingService;
 import kr.momo.service.meeting.dto.ConfirmedMeetingResponse;
+import kr.momo.service.meeting.dto.EntryMeetingResponse;
 import kr.momo.service.meeting.dto.MeetingConfirmRequest;
 import kr.momo.service.meeting.dto.MeetingConfirmResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
@@ -70,6 +71,12 @@ public class MeetingController implements MeetingControllerDocs {
     @GetMapping("/api/v1/meetings/{uuid}/confirm")
     public MomoApiResponse<ConfirmedMeetingResponse> findConfirmedMeeting(@PathVariable String uuid) {
         ConfirmedMeetingResponse response = meetingConfirmService.findByUuid(uuid);
+        return new MomoApiResponse<>(response);
+    }
+
+    @GetMapping("/api/v1/meetings/{uuid}/home")
+    public MomoApiResponse<EntryMeetingResponse> findMeetingEntry(@PathVariable String uuid) {
+        EntryMeetingResponse response = meetingService.findMeetingHome(uuid);
         return new MomoApiResponse<>(response);
     }
 

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -19,6 +19,7 @@ import kr.momo.exception.MomoException;
 import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.service.auth.JwtManager;
+import kr.momo.service.meeting.dto.EntryMeetingResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingCreateResponse;
 import kr.momo.service.meeting.dto.MeetingResponse;
@@ -108,6 +109,13 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));
         return MeetingSharingResponse.from(meeting);
+    }
+
+    @Transactional(readOnly = true)
+    public EntryMeetingResponse findMeetingHome(String uuid) {
+        Meeting meeting = meetingRepository.findByUuid(uuid)
+                .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
+        return EntryMeetingResponse.from(meeting);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
+++ b/backend/src/main/java/kr/momo/service/meeting/MeetingService.java
@@ -19,7 +19,7 @@ import kr.momo.exception.MomoException;
 import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.service.auth.JwtManager;
-import kr.momo.service.meeting.dto.EntryMeetingResponse;
+import kr.momo.service.meeting.dto.MeetingHomeResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingCreateResponse;
 import kr.momo.service.meeting.dto.MeetingResponse;
@@ -112,10 +112,10 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public EntryMeetingResponse findMeetingHome(String uuid) {
+    public MeetingHomeResponse findMeetingHome(String uuid) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
-        return EntryMeetingResponse.from(meeting);
+        return MeetingHomeResponse.from(meeting);
     }
 
     @Transactional

--- a/backend/src/main/java/kr/momo/service/meeting/dto/EntryMeetingResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/EntryMeetingResponse.java
@@ -1,0 +1,18 @@
+package kr.momo.service.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.momo.domain.meeting.Meeting;
+
+@Schema(description = "약속 입장 응답")
+public record EntryMeetingResponse(
+
+        @Schema(description = "약속 이름")
+        String meetingName,
+
+        @Schema(description = "약속 유형")
+        String type
+) {
+    public static EntryMeetingResponse from(Meeting meeting) {
+        return new EntryMeetingResponse(meeting.getName(), meeting.getType().name());
+    }
+}

--- a/backend/src/main/java/kr/momo/service/meeting/dto/MeetingHomeResponse.java
+++ b/backend/src/main/java/kr/momo/service/meeting/dto/MeetingHomeResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import kr.momo.domain.meeting.Meeting;
 
 @Schema(description = "약속 입장 응답")
-public record EntryMeetingResponse(
+public record MeetingHomeResponse(
 
         @Schema(description = "약속 이름")
         String meetingName,
@@ -12,7 +12,7 @@ public record EntryMeetingResponse(
         @Schema(description = "약속 유형")
         String type
 ) {
-    public static EntryMeetingResponse from(Meeting meeting) {
-        return new EntryMeetingResponse(meeting.getName(), meeting.getType().name());
+    public static MeetingHomeResponse from(Meeting meeting) {
+        return new MeetingHomeResponse(meeting.getName(), meeting.getType().name());
     }
 }

--- a/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/meeting/MeetingControllerTest.java
@@ -689,4 +689,18 @@ class MeetingControllerTest {
                 Timeslot.TIME_0600.startTime()
         );
     }
+
+    @DisplayName("약속 입장 정보를 조회하면 200 상태 코드를 응답한다.")
+    @Test
+    void findMeetingHome() {
+        Meeting meeting = MeetingFixture.MOVIE.create();
+        meeting = meetingRepository.save(meeting);
+
+        RestAssured.given().log().all()
+                .pathParam("uuid", meeting.getUuid())
+                .contentType(ContentType.JSON)
+                .when().get("/api/v1/meetings/{uuid}/home")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 import kr.momo.domain.attendee.Attendee;
 import kr.momo.domain.attendee.AttendeeRepository;
 import kr.momo.domain.availabledate.AvailableDate;
@@ -24,6 +25,7 @@ import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.fixture.AttendeeFixture;
 import kr.momo.fixture.MeetingFixture;
+import kr.momo.service.meeting.dto.EntryMeetingResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingResponse;
 import kr.momo.service.meeting.dto.MeetingSharingResponse;
@@ -257,5 +259,29 @@ class MeetingServiceTest {
         assertThatThrownBy(() -> meetingService.unlock(uuid, id))
                 .isInstanceOf(MomoException.class)
                 .hasMessage(AttendeeErrorCode.ACCESS_DENIED.message());
+    }
+
+    @DisplayName("UUID로 약속 입장 정보를 조회한다.")
+    @Test
+    void findMeetingHome() {
+        Meeting meeting = meetingRepository.save(MeetingFixture.GAME.create());
+        String uuid = meeting.getUuid();
+
+        EntryMeetingResponse result = meetingService.findMeetingHome(uuid);
+
+        assertAll(
+                () -> assertThat(result.meetingName()).isEqualTo(meeting.getName()),
+                () -> assertThat(result.type()).isEqualTo(meeting.getType().name())
+        );
+    }
+
+    @DisplayName("약속 입장 정보를 조회한다.")
+    @Test
+    void throwsExceptionWhenFindHomeNoMeeting() {
+        String uuid = UUID.randomUUID().toString();
+
+        assertThatThrownBy(() -> meetingService.findMeetingHome(uuid))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(MeetingErrorCode.NOT_FOUND_MEETING.message());
     }
 }

--- a/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/meeting/MeetingServiceTest.java
@@ -25,7 +25,7 @@ import kr.momo.exception.code.AttendeeErrorCode;
 import kr.momo.exception.code.MeetingErrorCode;
 import kr.momo.fixture.AttendeeFixture;
 import kr.momo.fixture.MeetingFixture;
-import kr.momo.service.meeting.dto.EntryMeetingResponse;
+import kr.momo.service.meeting.dto.MeetingHomeResponse;
 import kr.momo.service.meeting.dto.MeetingCreateRequest;
 import kr.momo.service.meeting.dto.MeetingResponse;
 import kr.momo.service.meeting.dto.MeetingSharingResponse;
@@ -267,7 +267,7 @@ class MeetingServiceTest {
         Meeting meeting = meetingRepository.save(MeetingFixture.GAME.create());
         String uuid = meeting.getUuid();
 
-        EntryMeetingResponse result = meetingService.findMeetingHome(uuid);
+        MeetingHomeResponse result = meetingService.findMeetingHome(uuid);
 
         assertAll(
                 () -> assertThat(result.meetingName()).isEqualTo(meeting.getName()),


### PR DESCRIPTION
## 관련 이슈

- resolves: #389 
## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
이슈에서 언급한 약속 입장 페이지에 대한 조회 API를 구현하였습니다.
반환 값들은 아래와 같습니다.
- 약속 이름
- 약속 유형

## 리뷰 요구사항

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

### 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요?

```java
@Query("SELECT e.field1, e.field2 FROM Entity e WHERE e.uuid=:uuid")
Optional<Entity> findMeetingHomeByUuid(String uuid);
```
두 개의 컬럼만 조회하는 로직에 대해 persistence 계층에 `@Query`를 추가할 필요가 있을까요? 현재 JPA에서 제공해주는 queryMethod를 재사용할 목적으로 `findByUuid()` 메서드를 사용하는데요. 아래 근거들이 타당할지 궁금하네요 :)
1. JPQL을 이용해 만든 메서드에 대해 관리 비용이 추가된다.
2. FetchType이 LAZY로 운용되므로 조인하는 데이터들을 모두 가져오지 않아 조회 로직에 부하가 그렇게 크지 않아 보인다.