### PR TITLE
[FE] 토스트 UI 구현

### DIFF
--- a/frontend/src/assets/images/attendeeCheck.svg
+++ b/frontend/src/assets/images/attendeeCheck.svg
@@ -1,3 +1,3 @@
 <svg width="current" height="current" viewBox="0 0 14 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12.3332 1L4.99984 8.33333L1.6665 5" stroke="#1E1E1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.3332 1L4.99984 8.33333L1.6665 5" stroke="current" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/src/assets/images/check.svg
+++ b/frontend/src/assets/images/check.svg
@@ -1,3 +1,3 @@
 <svg width="current" height="current" viewBox="0 0 100 100">
     <path d="M20,50 l20,20 l40,-40"/>
-  </svg>
+</svg>

--- a/frontend/src/assets/images/exclamation.svg
+++ b/frontend/src/assets/images/exclamation.svg
@@ -1,0 +1,3 @@
+<svg width="current" height="current" viewBox="0 0 2 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 9V0H2V9H0ZM0 14V12H2V14H0Z" fill="white"/>
+</svg>

--- a/frontend/src/components/_common/Toast/Toast.stories.tsx
+++ b/frontend/src/components/_common/Toast/Toast.stories.tsx
@@ -1,10 +1,15 @@
 import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
+import ToastProvider from '@contexts/ToastProvider';
+
+import useToast from '@hooks/useToast/useToast';
+
 import Toast from '.';
+import { Button } from '../Buttons/Button';
 
 const meta = {
-  title: 'Toast',
+  title: 'Components/Toast',
   component: Toast,
   parameters: {
     layout: 'centered',
@@ -29,11 +34,27 @@ const meta = {
       description: '토스트 UI에 애니메이션을 적용하기 위한 추가 상태입니다.',
     },
   },
+
+  decorators: [
+    (Story) => {
+      return (
+        <ToastProvider>
+          <div
+            css={css`
+              width: 43rem;
+            `}
+          >
+            <Story />
+          </div>
+        </ToastProvider>
+      );
+    },
+  ],
 } satisfies Meta<typeof Toast>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Toast>;
 
 export const Default: Story = {
   args: {
@@ -43,15 +64,7 @@ export const Default: Story = {
   },
 
   render: (args) => {
-    return (
-      <div
-        css={css`
-          width: 43rem;
-        `}
-      >
-        <Toast {...args} />
-      </div>
-    );
+    return <Toast {...args} />;
   },
 };
 
@@ -63,15 +76,7 @@ export const Warning: Story = {
   },
 
   render: (args) => {
-    return (
-      <div
-        css={css`
-          width: 43rem;
-        `}
-      >
-        <Toast {...args} />
-      </div>
-    );
+    return <Toast {...args} />;
   },
 };
 
@@ -83,13 +88,70 @@ export const Success: Story = {
   },
 
   render: (args) => {
+    return <Toast {...args} />;
+  },
+};
+
+export const ToastPlayground: Story = {
+  render: () => {
+    const { addToast } = useToast();
+
+    const renderDefaultToast = () => {
+      addToast({
+        type: 'default',
+        message: '안녕하세요, 내 이름은 기본 토스트입니다',
+        duration: 3000,
+      });
+    };
+
+    const renderSuccessToast = () => {
+      addToast({
+        type: 'success',
+        message: '안녕하세요, 내 이름은 성공 토스트입니다',
+        duration: 3000,
+      });
+    };
+
+    const renderWarningToast = () => {
+      addToast({
+        type: 'warning',
+        message: '안녕하세요, 내 이름은 경고 토스트입니다',
+        duration: 3000,
+      });
+    };
+
     return (
       <div
         css={css`
-          width: 43rem;
+          position: relative;
+
+          display: flex;
+          justify-content: center;
+
+          width: 100%;
+          height: 100vh;
         `}
       >
-        <Toast {...args} />
+        <div
+          css={css`
+            position: absolute;
+            bottom: 2.4rem;
+
+            display: flex;
+            flex-direction: column;
+            row-gap: 1.2rem;
+          `}
+        >
+          <Button variant="primary" size="s" onClick={renderDefaultToast}>
+            기본 토스트 렌더링하기
+          </Button>
+          <Button variant="primary" size="s" onClick={renderSuccessToast}>
+            성공 토스트 렌더링하기
+          </Button>
+          <Button variant="primary" size="s" onClick={renderWarningToast}>
+            경고 토스트 렌더링하기
+          </Button>
+        </div>
       </div>
     );
   },

--- a/frontend/src/components/_common/Toast/Toast.stories.tsx
+++ b/frontend/src/components/_common/Toast/Toast.stories.tsx
@@ -1,0 +1,96 @@
+import { css } from '@emotion/react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Toast from '.';
+
+const meta = {
+  title: 'Toast',
+  component: Toast,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    message: {
+      control: {
+        type: 'text',
+      },
+      description: '토스트 UI를 통해 사용자에게 전달할 메시지입니다.',
+    },
+    type: {
+      control: {
+        type: 'select',
+      },
+      options: ['default', 'warning', 'success'],
+    },
+    isOpen: {
+      control: {
+        type: 'boolean',
+      },
+      description: '토스트 UI에 애니메이션을 적용하기 위한 추가 상태입니다.',
+    },
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    type: 'default',
+    message: '안녕하세요, 내 이름은 기본 토스트입니다.',
+  },
+
+  render: (args) => {
+    return (
+      <div
+        css={css`
+          width: 43rem;
+        `}
+      >
+        <Toast {...args} />
+      </div>
+    );
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    isOpen: true,
+    type: 'warning',
+    message: '안녕하세요, 내 이름은 경고 토스트입니다.',
+  },
+
+  render: (args) => {
+    return (
+      <div
+        css={css`
+          width: 43rem;
+        `}
+      >
+        <Toast {...args} />
+      </div>
+    );
+  },
+};
+
+export const Success: Story = {
+  args: {
+    isOpen: true,
+    type: 'success',
+    message: '안녕하세요, 내 이름은 성공 토스트입니다.',
+  },
+
+  render: (args) => {
+    return (
+      <div
+        css={css`
+          width: 43rem;
+        `}
+      >
+        <Toast {...args} />
+      </div>
+    );
+  },
+};

--- a/frontend/src/components/_common/Toast/Toast.styles.ts
+++ b/frontend/src/components/_common/Toast/Toast.styles.ts
@@ -1,0 +1,67 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
+
+import theme from '@styles/theme';
+
+import type { ToastType } from './Toast.type';
+
+const toastSlideIn = keyframes`
+  from{
+    opacity: 0;
+  }to{
+    opacity: 1;
+  }
+`;
+
+const toastSlideOut = keyframes`
+  from{
+    opacity: 1;
+  }to{
+    opacity: 0;
+  }
+`;
+
+export const s_toastContainer = (isOpen: boolean) => css`
+  display: flex;
+  gap: 1.2rem;
+  align-items: center;
+
+  width: 100%;
+  height: 4.8rem;
+  padding: 1.2rem;
+
+  background-color: #a1a1aa;
+  border-radius: 1.6rem;
+  box-shadow: 0 0.4rem 0.4rem rgb(0 0 0 / 20%);
+
+  animation: ${isOpen ? toastSlideIn : toastSlideOut} 0.5s ease-in-out forwards;
+`;
+
+export const s_toastText = css`
+  ${theme.typography.captionBold}
+  color: ${theme.colors.white};
+`;
+
+const ICON_BACKGROUND_COLORS: Record<Exclude<ToastType, 'default'>, SerializedStyles> = {
+  warning: css`
+    background-color: #ef4545;
+  `,
+  success: css`
+    background-color: ${theme.colors.green.mediumDark};
+  `,
+};
+
+export const s_iconBackgroundColor = (type: Exclude<ToastType, 'default'>) => {
+  return ICON_BACKGROUND_COLORS[type];
+};
+
+export const s_iconContainer = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 2.4rem;
+  height: 2.4rem;
+
+  border-radius: 50%;
+`;

--- a/frontend/src/components/_common/Toast/Toast.type.ts
+++ b/frontend/src/components/_common/Toast/Toast.type.ts
@@ -1,0 +1,1 @@
+export type ToastType = 'default' | 'warning' | 'success';

--- a/frontend/src/components/_common/Toast/ToastContainer.tsx
+++ b/frontend/src/components/_common/Toast/ToastContainer.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+import Toast from '.';
+import type { ToastType } from './Toast.type';
+
+interface ToastContainerProps {
+  duration: number;
+  type: ToastType;
+  message: string;
+}
+
+const TOAST_ANIMATION_DURATION_TIME = 500;
+
+export default function ToastContainer({ duration, type, message }: ToastContainerProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    const animationTimer = setTimeout(() => {
+      setIsOpen(false);
+    }, duration - TOAST_ANIMATION_DURATION_TIME);
+
+    return () => {
+      clearTimeout(animationTimer);
+    };
+  }, [duration]);
+
+  return <Toast isOpen={isOpen} type={type} message={message} />;
+}

--- a/frontend/src/components/_common/Toast/ToastContainer.tsx
+++ b/frontend/src/components/_common/Toast/ToastContainer.tsx
@@ -4,14 +4,14 @@ import Toast from '.';
 import type { ToastType } from './Toast.type';
 
 interface ToastContainerProps {
-  duration: number;
+  duration?: number;
   type: ToastType;
   message: string;
 }
 
 const TOAST_ANIMATION_DURATION_TIME = 500;
 
-export default function ToastContainer({ duration, type, message }: ToastContainerProps) {
+export default function ToastContainer({ type, message, duration = 3000 }: ToastContainerProps) {
   const [isOpen, setIsOpen] = useState(true);
 
   useEffect(() => {

--- a/frontend/src/components/_common/Toast/ToastList/ToastList.styles.ts
+++ b/frontend/src/components/_common/Toast/ToastList/ToastList.styles.ts
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react';
+
+export const s_toastListContainer = css`
+  position: fixed;
+  z-index: 3;
+  top: 9rem;
+  left: 50%;
+  transform: translateX(-50%);
+
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  max-width: 43rem;
+  padding: 1.6rem;
+`;

--- a/frontend/src/components/_common/Toast/ToastList/ToastList.tsx
+++ b/frontend/src/components/_common/Toast/ToastList/ToastList.tsx
@@ -1,0 +1,20 @@
+import { createPortal } from 'react-dom';
+
+import useToast from '@hooks/useToast/useToast';
+
+import ToastContainer from '../ToastContainer';
+import { s_toastListContainer } from './ToastList.styles';
+
+export default function ToastList() {
+  const { toasts } = useToast();
+
+  return createPortal(
+    <div css={s_toastListContainer}>
+      {toasts &&
+        toasts.map(({ id, type, message, duration }) => (
+          <ToastContainer key={id} type={type} message={message} duration={duration} />
+        ))}
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/_common/Toast/index.tsx
+++ b/frontend/src/components/_common/Toast/index.tsx
@@ -1,0 +1,40 @@
+import Check from '@assets/images/attendeeCheck.svg';
+import Exclamation from '@assets/images/exclamation.svg';
+
+import theme from '@styles/theme';
+
+import {
+  s_iconBackgroundColor,
+  s_iconContainer,
+  s_toastContainer,
+  s_toastText,
+} from './Toast.styles';
+import type { ToastType } from './Toast.type';
+
+interface ToastProps {
+  isOpen: boolean;
+  type: ToastType;
+  message: string;
+}
+
+const iconMap: Record<ToastType, React.FC<React.SVGProps<SVGSVGElement>> | null> = {
+  default: null,
+  success: Check,
+  warning: Exclamation,
+};
+
+// 토스트 컴포넌트는 UI를 보여주는 책임만 가질 수 있도록 최대한 책임을 분리하고 스토리북을 활용한 UI 테스트를 쉽게할 수 있도록 한다.(@해리)
+export default function Toast({ isOpen, type = 'default', message }: ToastProps) {
+  const ToastIcon = iconMap[type];
+
+  return (
+    <div css={s_toastContainer(isOpen)}>
+      {type !== 'default' && (
+        <div css={[s_iconContainer, s_iconBackgroundColor(type)]}>
+          {ToastIcon && <ToastIcon width={16} height={16} stroke={theme.colors.white} />}
+        </div>
+      )}
+      <p css={s_toastText}>{message}</p>
+    </div>
+  );
+}

--- a/frontend/src/contexts/ToastProvider.tsx
+++ b/frontend/src/contexts/ToastProvider.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { createContext } from 'react';
 
 import type { ToastType } from '@components/_common/Toast/Toast.type';
@@ -9,7 +9,7 @@ interface ToastState {
   id: number;
   type: ToastType;
   message: string;
-  duration: number;
+  duration?: number;
 }
 
 interface ToastContextType {

--- a/frontend/src/contexts/ToastProvider.tsx
+++ b/frontend/src/contexts/ToastProvider.tsx
@@ -1,0 +1,56 @@
+import type { PropsWithChildren } from 'react';
+import React, { useState } from 'react';
+import { createContext } from 'react';
+
+import type { ToastType } from '@components/_common/Toast/Toast.type';
+import ToastList from '@components/_common/Toast/ToastList/ToastList';
+
+interface ToastState {
+  id: number;
+  type: ToastType;
+  message: string;
+  duration: number;
+}
+
+interface ToastContextType {
+  toasts: ToastState[];
+  addToast: ({ type, message, duration }: Omit<ToastState, 'id'>) => void;
+}
+
+export const ToastContext = createContext<ToastContextType | null>(null);
+
+export default function ToastProvider({ children }: PropsWithChildren) {
+  const [toasts, setToasts] = useState<ToastState[]>([]);
+
+  const checkAlreadyRenderedToast = (toastMessage: string) => {
+    return toasts.find(({ message }) => message === toastMessage);
+  };
+
+  const removeToast = (toastId: number) => {
+    setToasts((prevToasts) => prevToasts.filter(({ id }) => id !== toastId));
+  };
+
+  const addToast = ({ type, message, duration }: Omit<ToastState, 'id'>) => {
+    if (checkAlreadyRenderedToast(message)) return;
+
+    const toastId = Date.now();
+    const newToastState = {
+      id: toastId,
+      type,
+      message,
+      duration,
+    };
+
+    setToasts((prevToasts) => [...prevToasts, newToastState]);
+    setTimeout(() => {
+      removeToast(toastId);
+    }, duration);
+  };
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast }}>
+      <ToastList />
+      {children}
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/src/hooks/useToast/useToast.ts
+++ b/frontend/src/hooks/useToast/useToast.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+
+import { ToastContext } from '@contexts/ToastProvider';
+
+const useToast = () => {
+  const toastContext = useContext(ToastContext);
+
+  if (!toastContext) {
+    throw new Error('ToastContext를 사용할 수 없는 컴포넌트입니다.');
+  }
+
+  const { toasts, addToast } = toastContext;
+
+  return { toasts, addToast };
+};
+
+export default useToast;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,8 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
+import ToastProvider from '@contexts/ToastProvider';
+
 import globalStyles from '@styles/global';
 import theme from '@styles/theme';
 
@@ -51,7 +53,9 @@ enableMocking().then(() => {
       <ThemeProvider theme={theme}>
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools initialIsOpen={false} />
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </QueryClientProvider>
       </ThemeProvider>
     </React.StrictMode>,


### PR DESCRIPTION
## 관련 이슈

- resolves: #387 

- 사용자에게 피드백을 전달해줄 수 있는 토스트 UI를 구현했습니다.

## 작업 내용

### 디자인

![image](https://github.com/user-attachments/assets/c5351191-e5b4-4870-bcc2-fa1038b76adb)

모모 서비스에서 토스트 UI를 사용할 때, 위 이미지처럼 3가지 상황에서 사용할 수 있습니다. (성공, 경고, 기본)

위 토스트 UI 디자인을 끝낸 후, 아래와 같은 고민들을 하며 토스트 UI를 구현했습니다.

### `Toast.tsx` 컴포넌트는 최대한 UI와 관련된 책임을 가지도록

토스트 컴포넌트는 최대한 UI만 그리는 책임을 가지도록 구현했습니다. 그 이유는 아래와 같습니다.

- 스토리북으로 테스트하기 용이
  - 먄약 토스트 컴포넌트 내부에서 특정 시간이 지난 후 사라지게 하는 책임이나 사라질 때 애니메이션을 적용하도록 하는 책임을 부여한다면 스토리북으로 UI 테스트를 진행하기 힘들 것이라 판단했습니다.
  - 그래서, 최대한 UI와 관련된 책임만 가지도록 구현했어요.

- 하나의 책임만 가지니, 가독성과 유지보수 측면에서도 좋음

```tsx
// 토스트 컴포넌트는 UI를 보여주는 책임만 가질 수 있도록 최대한 책임을 분리하고 스토리북을 활용한 UI 테스트를 쉽게할 수 있도록 한다.(@해리)
export default function Toast({ isOpen, type = 'default', message }: ToastProps) {
  const ToastIcon = iconMap[type];

  return (
    <div css={s_toastContainer(isOpen)}>
      {type !== 'default' && (
        <div css={[s_iconContainer, s_iconBackgroundColor(type)]}>
          {ToastIcon && <ToastIcon width={16} height={16} stroke={theme.colors.white} />}
        </div>
      )}
      <p css={s_toastText}>{message}</p>
    </div>
  );
}
```

### 리액트 컴포넌트는 언마운트되었을 때, 바로 DOM 트리에서 사라지므로 사라지는 애니메이션을 적용하기 힘들다, 어떻게 해결할 것인가?

토스트 컴포넌트가 최대한 UI와 관련된 책임만 가지도록 구현한 후, 사라지는 애니메이션에 대한 책임을 어떤 레이어에서 가질 것인가? 에 대한 고민을 추가로 하게 되었습니다. `ToastProvider`, `ToastList` 컴포넌트에서도 충분히 책임을 가질 수 있지만 결론부터 말씀드리자면 `ToastContainer` 컴포넌트를 추가로 구현하게 되었습니다. 그 이유는 아래와 같습니다.

- ToastProvider 컴포넌트는 토스트의 렌더링 상태 관리 책임을 가진다.
- ToastList 컴포넌트는 토스트 컴포넌트의 레이아웃을 결정하는 책임을 가진다.

위 이유들에서도 확인할 수 있듯, 두 컴포넌트는 이미 책임을 충분히 가지고 있으므로 추가로 부여하기 보다는 토스트 컴포넌트를 한 번 더 감싸는 `ToastContainer` 컴포넌트를 구현하는 것이 좋을 것 같다고 판단했어요. 이 부분에 대한 논의는 언제든지 환영입니다 :)

### 여러개의 토스트 메시지를 보여주는 것으로 결정, 단 메시지가 같은 경우에는 해당 토스트 UI 렌더링을 무시할 수 있도록 한다.

여러개의 토스트 메시지를 보여줄 것인지에 대해서 논의를 했었는데요, 여러개의 토스트 메시지를 보여줄 수 있도록 구현하되 동일한 피드백을 전달해 주고 있는 토스트가 렌더링 중이라면, 추가로 렌더링되지 않는 방향으로 구현했습니다.   
모모 서비스에서 한 번에 하나의 토스트만 보여준다면 여러 피드백을 동시에 전달해야 하는 경우에는 대처할 수 없다고 생각한게 가장 큰 이유입니다.  동일한 메시지를 전달하는 토스트 컴포넌트를 계속해서 렌더링한다면 토스트 컴포넌트가 계속 쌓여서 UX 측면에서 좋지않다고 판단한 것도 의사 결정 요소입니다 :) 

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

### 결국, 해결하지 못한 렌더링 효율 문제

토스트 렌더링을 담당하는 컨텍스트(ToastStateContext), 토스트 렌더링을 트리거하는 컨텍스트(ToastDispatchContext)를 분리해서 렌더링 효율 문제를 해결하려고 했으나 해결하지 못한 채 PR을 보냅니다. 해결하지 못한 이유는 렌더링을 트리거하는 addToast 함수에서 현재 렌더링된 토스트의 상태(ToastStateContext)를 참조하기 때문입니다.

```tsx
export default function ToastProvider({ children }: PropsWithChildren) {
  const [toasts, setToasts] = useState<ToastState[]>([]);

  const checkAlreadyRenderedToast = (toastMessage: string) => {
    return toasts.find(({ message }) => message === toastMessage);
  };

  const removeToast = (toastId: number) => {
    setToasts((prevToasts) => prevToasts.filter(({ id }) => id !== toastId));
  };

  const addToast = ({ type, message, duration }: Omit<ToastState, 'id'>) => {
    if (checkAlreadyRenderedToast(message)) return;

    const toastId = Date.now();
    const newToastState = {
      id: toastId,
      type,
      message,
      duration,
    };

    setToasts((prevToasts) => [...prevToasts, newToastState]);
    setTimeout(() => {
      removeToast(toastId);
    }, duration);
  };
```

위 구현을 살펴보면 addToast 함수에서 이미 렌더링된 토스트인지 확인 절차를 거칩니다. 이 때 현재 렌더링된 토스트들의 상태를 참조하고 있기 때문에 컨텍스트를 분리할 수 없어 렌더링 효율 문제를 해결할 수 없었습니다...:( 슬프네요

### 모달, 토스트가 사라질 때 애니메이션을 적용하는 상태관리 커스텀 훅?

토스트 컴포넌트를 구현하기 전만해도 useAnimation이라는 커스텀 훅을 구현하고 모달, 토스트가 사라질 때 애니메이션을 적용할 수 있도록 하는 책임을 구분하려고 했는데요...결론적으로 구현하지는 못했습니다.

모달은 사용자가 특정 행동을 할 때, 사라지고 토스트는 특정 시간이 지나면 자동으로 사라지는데 이 두 상황을 모두 커버할 수 있는 커스텀 훅을 구현하기 위한 아이디어가 떠오르지 않아 너무 많은 시간이 지체될까바 일단 PR을 보냅니다.

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
