### PR TITLE
[FE] 날짜만 입력 시, 약속 추천 필터링 기능 제거

### DIFF
--- a/frontend/src/pages/MeetingRecommendPage/components/MeetingTimeRecommends.tsx
+++ b/frontend/src/pages/MeetingRecommendPage/components/MeetingTimeRecommends.tsx
@@ -45,14 +45,16 @@ export default function MeetingTimeRecommends({ uuid, attendeeNames }: MeetingRe
         ))}
       </section>
       <span css={s_tipInfo}>원하는 참여인원을 선택해 보세요 :)</span>
-      <Dropdown
-        value={recommendType}
-        onChange={(e) => handleChangeRecommendType(e.target.value)}
-        options={[
-          { value: 'earliest', label: '빠르게 만나고 싶어요' },
-          { value: 'longTerm', label: '길게 만나고 싶어요' },
-        ]}
-      />
+      {meetingRecommendResponse && meetingRecommendResponse.type === 'DATETIME' && (
+        <Dropdown
+          value={recommendType}
+          onChange={(e) => handleChangeRecommendType(e.target.value)}
+          options={[
+            { value: 'earliest', label: '빠르게 만나고 싶어요' },
+            { value: 'longTerm', label: '길게 만나고 싶어요' },
+          ]}
+        />
+      )}
       {meetingRecommendResponse &&
         meetingRecommendResponse.recommendedSchedules.map((recommendInfo, index) =>
           meetingRecommendResponse.type === 'DATETIME' ? (


### PR DESCRIPTION
## 관련 이슈

- resolves: #399 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

- 약속 type이 DATETIME일 때만 필터링 기능을 렌더링 하도록 구현

## 특이 사항

날짜만 선택 기능으로 추천받을 때 500에러 발생 및 "길게 만나고 싶어요"라는 필터링 컨텍스트가 "시간"에만 필요한 기능이기 때문에 날짜만 선택 시 불필요한 필터링 기능이라 판단하고 제거

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
