### PR TITLE
[BE] 배포 서버 CD 작업이 하나의 runner만 실행되는 문제와 앱을 제외한 컨테이너가 내려가는 문제를 해결

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -3,7 +3,7 @@ name: Backend Prod CD
 on:
   workflow_dispatch:
   push:
-    branches: ['main']
+    branches: [ 'main' ]
 
 jobs:
   detect-changes:
@@ -89,7 +89,7 @@ jobs:
         runner: [ prod-a, prod-b ]
       # fail-fast 옵션을 명시적으로 설정
       fail-fast: true
-    runs-on: [self-hosted, linux, ARM64, ${{ matrix.runner }}]
+    runs-on: [ self-hosted, linux, ARM64, ${ { matrix.runner } } ]
     defaults:
       run:
         shell: bash
@@ -109,20 +109,10 @@ jobs:
       - name: docker pull
         run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/momo-api-prod
 
-      # 2. 기존 컨테이너 중지
-      - name: docker stop container
-        run: docker stop $(docker ps -q) 2>/dev/null || true
+      # 2. 실행 컨테이너 중 app 서비스만 재시작
+      - name: Restart app service
+        run: docker compose -f $HOME/security/docker-compose-prod.yml restart app --no-deps
 
-      # 3. 도커 컨테이너 실행
-      - name: docker run new container
-        run: >-
-          docker run --name momo-api-prod
-          --rm -d -p 8080:8080
-          --volume=$HOME/security:/momo/security:ro
-          --volume=$HOME/logs:/momo/logs
-          --env SPRING_PROFILE=prod
-          ${{ secrets.DOCKERHUB_USERNAME }}/momo-api-prod
-
-      # 4. 미사용 이미지를 정리
+      # 3. 미사용 이미지를 정리
       - name: delete old docker image
         run: docker system prune -f

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -83,7 +83,13 @@ jobs:
 
   be-depoly:
     needs: be-build
-    runs-on: [self-hosted, linux, ARM64, prod]
+    strategy:
+      matrix:
+        # 매트릭스 전략으로 여러 runner를 사용할 수 있도록 설정
+        runner: [ prod-a, prod-b ]
+      # fail-fast 옵션을 명시적으로 설정
+      fail-fast: true
+    runs-on: [self-hosted, linux, ARM64, ${{ matrix.runner }}]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## 관련 이슈

- resolves: #401 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

### 배포 서버 CD 작업이 하나의 runner만 실행되는 문제

기존 설정은 이중화된 배포 서버의 두 개의 self hosted runner를 `prod`라는 하나의 label로 실행하려고 했습니다.
github workflow의 label은 특정 러너로 실행하는 것에 목적이 있습니다. 두 runner 중 하나만 실행되고 있었습니다.

각 runner의 label을 나누고, 워크플로의 매트릭스 전략을 통해 하나의 job을 여러 번 실행하는 방법을 사용하여 문제를 해결합니다.

### 앱을 제외한 컨테이너가 내려가는 문제

기존 워크플로는 모든 도커 컨테이너를 중단한 후 `docker run`으로 배포하였습니다. 하지만 배포 서버를 모니터링하기 위한 컨테이너들이 추가 되었고 도커 컴포즈로 관리하게 되었습니다. 이에 맞게 배포 작업을 수정했습니다.

### 테스트

개발 서버 CD 워크플로가 먼저 잘 작동한 것을 확인했습니다.
로컬에서 하나의 저장소에 두 runner가 동작하는지 매트릭스 전략을 테스트해봤습니다.

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

참고 자료
- [about-workflows#using-a-matrix](https://docs.github.com/ko/actions/writing-workflows/about-workflows#using-a-matrix)
- [running-variations-of-jobs-in-a-workflow](https://docs.github.com/ko/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow)
- [workflow-syntax-for-github-actions#jobsjob_idstrategymatrix](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)
- [choosing-the-runner-for-a-job#choosing-self-hosted-runners](https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#choosing-self-hosted-runners)
## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
