### PR TITLE
[BE] 최소 시간을 보장하는 추천 로직 추가

### DIFF
--- a/backend/src/main/java/kr/momo/controller/schedule/ScheduleController.java
+++ b/backend/src/main/java/kr/momo/controller/schedule/ScheduleController.java
@@ -1,20 +1,20 @@
 package kr.momo.controller.schedule;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import kr.momo.controller.MomoApiResponse;
 import kr.momo.controller.auth.AuthAttendee;
 import kr.momo.service.schedule.ScheduleService;
 import kr.momo.service.schedule.dto.AttendeeScheduleResponse;
 import kr.momo.service.schedule.dto.RecommendedSchedulesResponse;
 import kr.momo.service.schedule.dto.ScheduleCreateRequest;
+import kr.momo.service.schedule.dto.ScheduleRecommendRequest;
 import kr.momo.service.schedule.dto.SchedulesResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -52,13 +52,10 @@ public class ScheduleController implements ScheduleControllerDocs {
 
     @GetMapping("/api/v1/meetings/{uuid}/recommended-schedules")
     public MomoApiResponse<RecommendedSchedulesResponse> recommendSchedules(
-            @PathVariable String uuid,
-            @RequestParam String recommendType,
-            @RequestParam List<String> attendeeNames,
-            @RequestParam(value = "minTime", defaultValue = "0") int minTime
+            @PathVariable String uuid, @ModelAttribute @Valid ScheduleRecommendRequest request
     ) {
         RecommendedSchedulesResponse response = scheduleService.recommendSchedules(
-                uuid, recommendType, attendeeNames, minTime
+                uuid, request.recommendType(), request.attendeeNames(), request.minTime()
         );
         return new MomoApiResponse<>(response);
     }

--- a/backend/src/main/java/kr/momo/controller/schedule/ScheduleController.java
+++ b/backend/src/main/java/kr/momo/controller/schedule/ScheduleController.java
@@ -52,10 +52,13 @@ public class ScheduleController implements ScheduleControllerDocs {
 
     @GetMapping("/api/v1/meetings/{uuid}/recommended-schedules")
     public MomoApiResponse<RecommendedSchedulesResponse> recommendSchedules(
-            @PathVariable String uuid, @RequestParam String recommendType, @RequestParam List<String> attendeeNames
+            @PathVariable String uuid,
+            @RequestParam String recommendType,
+            @RequestParam List<String> attendeeNames,
+            @RequestParam(value = "minTime", defaultValue = "0") int minTime
     ) {
         RecommendedSchedulesResponse response = scheduleService.recommendSchedules(
-                uuid, recommendType, attendeeNames
+                uuid, recommendType, attendeeNames, minTime
         );
         return new MomoApiResponse<>(response);
     }

--- a/backend/src/main/java/kr/momo/controller/schedule/ScheduleControllerDocs.java
+++ b/backend/src/main/java/kr/momo/controller/schedule/ScheduleControllerDocs.java
@@ -98,9 +98,11 @@ public interface ScheduleControllerDocs {
     @ApiSuccessResponse.Ok("추천 일정 조회 성공")
     MomoApiResponse<RecommendedSchedulesResponse> recommendSchedules(
             @PathVariable @Schema(description = "약속 UUID") String uuid,
-            @RequestParam @Schema(description = "추천 기준(이른 시간 순 / 길게 볼 수 있는 순)", example = "earliest")
+            @RequestParam @Schema(description = "추천 기준(이른 시간 순 / 길게 볼 수 있는 순 / 최소 시간 보장 순)", example = "earliest")
             String recommendType,
             @RequestParam @Schema(description = "추천 대상 참여자 이름", example = "페드로, 재즈, 모모")
-            List<String> attendeeNames
+            List<String> attendeeNames,
+            @RequestParam @Schema(description = "최소 만남 시간(30분 단위의 분)", example = "0, 30, 60, 90")
+            int minTime
     );
 }

--- a/backend/src/main/java/kr/momo/controller/schedule/ScheduleControllerDocs.java
+++ b/backend/src/main/java/kr/momo/controller/schedule/ScheduleControllerDocs.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import kr.momo.controller.MomoApiResponse;
 import kr.momo.controller.annotation.ApiErrorResponse;
 import kr.momo.controller.annotation.ApiSuccessResponse;
@@ -15,10 +14,11 @@ import kr.momo.controller.auth.AuthAttendee;
 import kr.momo.service.schedule.dto.AttendeeScheduleResponse;
 import kr.momo.service.schedule.dto.RecommendedSchedulesResponse;
 import kr.momo.service.schedule.dto.ScheduleCreateRequest;
+import kr.momo.service.schedule.dto.ScheduleRecommendRequest;
 import kr.momo.service.schedule.dto.SchedulesResponse;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Schedule", description = "일정 API")
 public interface ScheduleControllerDocs {
@@ -90,7 +90,7 @@ public interface ScheduleControllerDocs {
                     추천 기준에 따라 이른 시간 순 혹은 길게 볼 수 있는 순으로 추천합니다.
                     - earliest: 이른 시간 순
                     - longTerm: 길게 볼 수 있는 순
-                                        
+                    
                     추천 연산에 사용할 참여자 이름을 명시하여 필터링할 수 있습니다.<br>
                     약속 내의 모든 참여자가 전달된 경우 일부 참여자들이 참여할 수 있는 일정을 함께 추천하며,<br>
                     이외의 경우 전달된 참여자들이 모두 참여할 수 있는 일정이 추천됩니다.
@@ -98,11 +98,6 @@ public interface ScheduleControllerDocs {
     @ApiSuccessResponse.Ok("추천 일정 조회 성공")
     MomoApiResponse<RecommendedSchedulesResponse> recommendSchedules(
             @PathVariable @Schema(description = "약속 UUID") String uuid,
-            @RequestParam @Schema(description = "추천 기준(이른 시간 순 / 길게 볼 수 있는 순 / 최소 시간 보장 순)", example = "earliest")
-            String recommendType,
-            @RequestParam @Schema(description = "추천 대상 참여자 이름", example = "페드로, 재즈, 모모")
-            List<String> attendeeNames,
-            @RequestParam @Schema(description = "최소 만남 시간(30분 단위의 분)", example = "0, 30, 60, 90")
-            int minTime
+            @ModelAttribute @Valid ScheduleRecommendRequest request
     );
 }

--- a/backend/src/main/java/kr/momo/domain/schedule/DateInterval.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/DateInterval.java
@@ -5,10 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-public record DateInterval(
-        LocalDate startDate,
-        LocalDate endDate
-) implements RecommendInterval {
+public record DateInterval(LocalDate startDate, LocalDate endDate) implements RecommendInterval {
 
     @Override
     public boolean isSequential(RecommendInterval nextInterval) {

--- a/backend/src/main/java/kr/momo/domain/schedule/DateTimeInterval.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/DateTimeInterval.java
@@ -3,10 +3,7 @@ package kr.momo.domain.schedule;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-public record DateTimeInterval(
-        LocalDateTime startDateTime,
-        LocalDateTime endDateTime
-) implements RecommendInterval {
+public record DateTimeInterval(LocalDateTime startDateTime, LocalDateTime endDateTime) implements RecommendInterval {
 
     @Override
     public boolean isSequential(RecommendInterval nextInterval) {

--- a/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/ScheduleRepository.java
@@ -23,14 +23,14 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     void deleteByAttendee(Attendee attendee);
 
     @Query("""
-                SELECT
-                    new kr.momo.domain.schedule.DateAndTimeslot(ad.date, s.timeslot)
-                FROM Schedule s
-                JOIN s.availableDate ad
-                WHERE s.attendee IN :essentialAttendees
-                GROUP BY ad.date, s.timeslot
-                HAVING COUNT(s.attendee.id) = :#{#essentialAttendees.size()}
-                ORDER BY ad.date ASC, s.timeslot ASC
+            SELECT
+                new kr.momo.domain.schedule.DateAndTimeslot(ad.date, s.timeslot)
+            FROM Schedule s
+            JOIN s.availableDate ad
+            WHERE s.attendee IN :essentialAttendees
+            GROUP BY ad.date, s.timeslot
+            HAVING COUNT(s.attendee.id) = :#{#essentialAttendees.size()}
+            ORDER BY ad.date ASC, s.timeslot ASC
             """)
     List<DateAndTimeslot> findAllDateAndTimeslotByEssentialAttendees(
             @Param("essentialAttendees") List<Attendee> essentialAttendees

--- a/backend/src/main/java/kr/momo/domain/schedule/recommend/CandidateSchedule.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/recommend/CandidateSchedule.java
@@ -40,12 +40,11 @@ public record CandidateSchedule(RecommendInterval dateTimeInterval, AttendeeGrou
     private static void addWhenLongerOrEqualThanMinTime(
             List<CandidateSchedule> subList, List<CandidateSchedule> mergedSchedules, int minSize
     ) {
-        if (minSize > subList.size()) {
-            return;
+        if (minSize <= subList.size()) {
+            subList.stream()
+                    .reduce(CandidateSchedule::merge)
+                    .ifPresent(mergedSchedules::add);
         }
-        subList.stream()
-                .reduce(CandidateSchedule::merge)
-                .ifPresent(mergedSchedules::add);
     }
 
     private static boolean isSequential(

--- a/backend/src/main/java/kr/momo/domain/schedule/recommend/CandidateSchedule.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/recommend/CandidateSchedule.java
@@ -31,13 +31,13 @@ public record CandidateSchedule(RecommendInterval dateTimeInterval, AttendeeGrou
                     .takeWhile(i -> i == headIdx || isSequential(i, sortedSchedules, isContinuous))
                     .map(sortedSchedules::get)
                     .toList();
-            addWhenLongerOrEqualThanMinTime(subList, mergedSchedules, minSize);
+            addIfLongerThanOrEqualToMinTime(subList, mergedSchedules, minSize);
             idx += subList.size();
         }
         return mergedSchedules;
     }
 
-    private static void addWhenLongerOrEqualThanMinTime(
+    private static void addIfLongerThanOrEqualToMinTime(
             List<CandidateSchedule> subList, List<CandidateSchedule> mergedSchedules, int minSize
     ) {
         if (minSize <= subList.size()) {

--- a/backend/src/main/java/kr/momo/domain/schedule/recommend/CandidateSchedule.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/recommend/CandidateSchedule.java
@@ -9,12 +9,8 @@ import java.util.stream.Stream;
 import kr.momo.domain.attendee.AttendeeGroup;
 import kr.momo.domain.schedule.DateTimeInterval;
 import kr.momo.domain.schedule.RecommendInterval;
-import kr.momo.exception.MomoException;
-import kr.momo.exception.code.ScheduleErrorCode;
 
 public record CandidateSchedule(RecommendInterval dateTimeInterval, AttendeeGroup attendeeGroup) {
-
-    private static final int MINIMUM_MIN_SIZE = 0;
 
     public static CandidateSchedule of(
             LocalDateTime startDateTime, LocalDateTime endDateTime, AttendeeGroup attendeeGroup
@@ -44,9 +40,6 @@ public record CandidateSchedule(RecommendInterval dateTimeInterval, AttendeeGrou
     private static void addWhenLongerOrEqualThanMinTime(
             List<CandidateSchedule> subList, List<CandidateSchedule> mergedSchedules, int minSize
     ) {
-        if (minSize < MINIMUM_MIN_SIZE) {
-            throw new MomoException(ScheduleErrorCode.INVALID_MIN_TIME);
-        }
         if (minSize > subList.size()) {
             return;
         }

--- a/backend/src/main/java/kr/momo/domain/schedule/recommend/RecommendedScheduleSortStandard.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/recommend/RecommendedScheduleSortStandard.java
@@ -9,9 +9,7 @@ import lombok.Getter;
 public enum RecommendedScheduleSortStandard {
 
     EARLIEST_ORDER("earliest", new EarliestFirstSorter()),
-    LONG_TERM_ORDER("longTerm", new LongTermFirstSorter()),
-    MIN_TIME_EARLIER_ORDER("minTime", new EarliestFirstSorter())
-    ;
+    LONG_TERM_ORDER("longTerm", new LongTermFirstSorter());
 
     private final String type;
     private final CandidateScheduleSorter sorter;

--- a/backend/src/main/java/kr/momo/domain/schedule/recommend/RecommendedScheduleSortStandard.java
+++ b/backend/src/main/java/kr/momo/domain/schedule/recommend/RecommendedScheduleSortStandard.java
@@ -9,7 +9,9 @@ import lombok.Getter;
 public enum RecommendedScheduleSortStandard {
 
     EARLIEST_ORDER("earliest", new EarliestFirstSorter()),
-    LONG_TERM_ORDER("longTerm", new LongTermFirstSorter());
+    LONG_TERM_ORDER("longTerm", new LongTermFirstSorter()),
+    MIN_TIME_EARLIER_ORDER("minTime", new EarliestFirstSorter())
+    ;
 
     private final String type;
     private final CandidateScheduleSorter sorter;

--- a/backend/src/main/java/kr/momo/exception/code/ScheduleErrorCode.java
+++ b/backend/src/main/java/kr/momo/exception/code/ScheduleErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 public enum ScheduleErrorCode implements ErrorCodeType {
 
     INVALID_SCHEDULE_TIMESLOT(HttpStatus.BAD_REQUEST, "해당 시간을 선택할 수 없습니다. 주최자가 설정한 시간만 선택 가능합니다."),
-    INVALID_SCHEDULE_RECOMMEND_TYPE(HttpStatus.BAD_REQUEST, "해당 추천 기준이 없습니다.");
+    INVALID_SCHEDULE_RECOMMEND_TYPE(HttpStatus.BAD_REQUEST, "해당 추천 기준이 없습니다."),
+    INVALID_MIN_TIME(HttpStatus.BAD_REQUEST, "최소 시간 입력이 잘못되었습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
@@ -122,7 +122,9 @@ public class ScheduleService {
     }
 
     @Transactional(readOnly = true)
-    public RecommendedSchedulesResponse recommendSchedules(String uuid, String recommendType, List<String> names) {
+    public RecommendedSchedulesResponse recommendSchedules(
+            String uuid, String recommendType, List<String> names, int minimumTime
+    ) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.NOT_FOUND_MEETING));
         AttendeeGroup attendeeGroup = new AttendeeGroup(attendeeRepository.findAllByMeeting(meeting));
@@ -131,11 +133,13 @@ public class ScheduleService {
         ScheduleRecommender recommender = scheduleRecommenderFactory.getRecommenderOf(
                 attendeeGroup, filteredGroup
         );
-        List<CandidateSchedule> recommendedResult = recommender.recommend(filteredGroup, recommendType,
-                meeting.getType());
+        List<CandidateSchedule> recommendedResult = recommender.recommend(
+                filteredGroup, recommendType, meeting.getType(), minimumTime
+        );
 
         List<RecommendedScheduleResponse> scheduleResponses = RecommendedScheduleResponse.fromCandidateSchedules(
-                recommendedResult);
+                recommendedResult
+        );
         return RecommendedSchedulesResponse.of(meeting.getType(), scheduleResponses);
     }
 }

--- a/backend/src/main/java/kr/momo/service/schedule/dto/ScheduleRecommendRequest.java
+++ b/backend/src/main/java/kr/momo/service/schedule/dto/ScheduleRecommendRequest.java
@@ -1,0 +1,23 @@
+package kr.momo.service.schedule.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Schema(description = "일정 추천 요청")
+public record ScheduleRecommendRequest(
+
+        @NotEmpty
+        @Schema(description = "추천 기준(이른 시간 순 / 길게 볼 수 있는 순 / 최소 시간 보장 순)", example = "earliest")
+        String recommendType,
+
+        @NotEmpty
+        @Schema(description = "추천 대상 참여자 이름", example = "페드로, 재즈, 모모")
+        List<String> attendeeNames,
+
+        @Schema(description = "최소 만남 시간(시간 단위)", example = "0, 1, 2, 3")
+        @Min(value = 0, message = "최소 시간은 0보다 작을 수 없습니다.")
+        int minTime
+) {
+}

--- a/backend/src/main/java/kr/momo/service/schedule/dto/ScheduleRecommendRequest.java
+++ b/backend/src/main/java/kr/momo/service/schedule/dto/ScheduleRecommendRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 public record ScheduleRecommendRequest(
 
         @NotEmpty
-        @Schema(description = "추천 기준(이른 시간 순 / 길게 볼 수 있는 순 / 최소 시간 보장 순)", example = "earliest")
+        @Schema(description = "추천 기준(이른 시간 순 / 길게 볼 수 있는 순)", example = "earliest")
         String recommendType,
 
         @NotEmpty
@@ -18,6 +18,12 @@ public record ScheduleRecommendRequest(
 
         @Schema(description = "최소 만남 시간(시간 단위)", example = "0, 1, 2, 3")
         @Min(value = 0, message = "최소 시간은 0보다 작을 수 없습니다.")
-        int minTime
+        Integer minTime
 ) {
+
+    public ScheduleRecommendRequest {
+        if (minTime == null) {
+            minTime = 0;
+        }
+    }
 }

--- a/backend/src/main/java/kr/momo/service/schedule/recommend/FilteredScheduleRecommender.java
+++ b/backend/src/main/java/kr/momo/service/schedule/recommend/FilteredScheduleRecommender.java
@@ -18,8 +18,9 @@ public class FilteredScheduleRecommender extends ScheduleRecommender {
     }
 
     @Override
-    protected List<CandidateSchedule> extractProperSortedDiscreteScheduleOf(AttendeeGroup filteredGroup,
-                                                                            MeetingType type) {
+    protected List<CandidateSchedule> extractProperSortedDiscreteScheduleOf(
+            AttendeeGroup filteredGroup, MeetingType type
+    ) {
         return findAllScheduleAvailableByEveryAttendee(filteredGroup);
     }
 

--- a/backend/src/main/java/kr/momo/service/schedule/recommend/ScheduleRecommender.java
+++ b/backend/src/main/java/kr/momo/service/schedule/recommend/ScheduleRecommender.java
@@ -14,14 +14,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public abstract class ScheduleRecommender {
 
-    private static final int HALF_HOUR_INTERVAL = 30;
+    private static final int ONE_HOUR_TIME_INTERVAL_SIZE = 2;
 
     protected final ScheduleRepository scheduleRepository;
 
     public List<CandidateSchedule> recommend(
             AttendeeGroup group, String recommendType, MeetingType meetingType, int minTime
     ) {
-        int minSize = minTime / HALF_HOUR_INTERVAL;
+        int minSize = minTime * ONE_HOUR_TIME_INTERVAL_SIZE;
         List<CandidateSchedule> mergedCandidateSchedules = calcCandidateSchedules(group, meetingType, minSize);
         sortSchedules(mergedCandidateSchedules, recommendType);
         return mergedCandidateSchedules.stream()

--- a/backend/src/main/java/kr/momo/service/schedule/recommend/ScheduleRecommender.java
+++ b/backend/src/main/java/kr/momo/service/schedule/recommend/ScheduleRecommender.java
@@ -14,19 +14,24 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public abstract class ScheduleRecommender {
 
+    private static final int HALF_HOUR_INTERVAL = 30;
+
     protected final ScheduleRepository scheduleRepository;
 
-    public List<CandidateSchedule> recommend(AttendeeGroup group, String recommendType, MeetingType meetingType) {
-        List<CandidateSchedule> mergedCandidateSchedules = calcCandidateSchedules(group, meetingType);
+    public List<CandidateSchedule> recommend(
+            AttendeeGroup group, String recommendType, MeetingType meetingType, int minTime
+    ) {
+        int minSize = minTime / HALF_HOUR_INTERVAL;
+        List<CandidateSchedule> mergedCandidateSchedules = calcCandidateSchedules(group, meetingType, minSize);
         sortSchedules(mergedCandidateSchedules, recommendType);
         return mergedCandidateSchedules.stream()
                 .limit(getMaxRecommendCount())
                 .toList();
     }
 
-    private List<CandidateSchedule> calcCandidateSchedules(AttendeeGroup group, MeetingType type) {
+    private List<CandidateSchedule> calcCandidateSchedules(AttendeeGroup group, MeetingType type, int minSize) {
         List<CandidateSchedule> intersectedDateTimes = extractProperSortedDiscreteScheduleOf(group, type);
-        return CandidateSchedule.mergeContinuous(intersectedDateTimes, this::isContinuous);
+        return CandidateSchedule.mergeContinuous(intersectedDateTimes, this::isContinuous, minSize);
     }
 
     private void sortSchedules(List<CandidateSchedule> mergedCandidateSchedules, String recommendType) {
@@ -35,7 +40,9 @@ public abstract class ScheduleRecommender {
         sorter.sort(mergedCandidateSchedules);
     }
 
-    protected abstract List<CandidateSchedule> extractProperSortedDiscreteScheduleOf(AttendeeGroup group, MeetingType type);
+    protected abstract List<CandidateSchedule> extractProperSortedDiscreteScheduleOf(
+            AttendeeGroup group, MeetingType type
+    );
 
     protected abstract boolean isContinuous(CandidateSchedule current, CandidateSchedule next);
 

--- a/backend/src/main/java/kr/momo/service/schedule/recommend/ScheduleRecommender.java
+++ b/backend/src/main/java/kr/momo/service/schedule/recommend/ScheduleRecommender.java
@@ -29,15 +29,15 @@ public abstract class ScheduleRecommender {
         return CandidateSchedule.mergeContinuous(intersectedDateTimes, this::isContinuous);
     }
 
-    abstract List<CandidateSchedule> extractProperSortedDiscreteScheduleOf(AttendeeGroup group, MeetingType type);
-
-    abstract boolean isContinuous(CandidateSchedule current, CandidateSchedule next);
-
     private void sortSchedules(List<CandidateSchedule> mergedCandidateSchedules, String recommendType) {
         RecommendedScheduleSortStandard sortStandard = RecommendedScheduleSortStandard.from(recommendType);
         CandidateScheduleSorter sorter = sortStandard.getSorter();
         sorter.sort(mergedCandidateSchedules);
     }
 
-    abstract long getMaxRecommendCount();
+    protected abstract List<CandidateSchedule> extractProperSortedDiscreteScheduleOf(AttendeeGroup group, MeetingType type);
+
+    protected abstract boolean isContinuous(CandidateSchedule current, CandidateSchedule next);
+
+    protected abstract long getMaxRecommendCount();
 }

--- a/backend/src/main/java/kr/momo/service/schedule/recommend/TotalScheduleRecommender.java
+++ b/backend/src/main/java/kr/momo/service/schedule/recommend/TotalScheduleRecommender.java
@@ -50,7 +50,7 @@ public class TotalScheduleRecommender extends ScheduleRecommender {
     }
 
     @Override
-    long getMaxRecommendCount() {
+    protected long getMaxRecommendCount() {
         return MAXIMUM_RECOMMEND_COUNT;
     }
 }

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -154,7 +154,7 @@ class ScheduleControllerTest {
     void recommendSchedules() {
         RestAssured.given().log().all()
                 .pathParam("uuid", meeting.getUuid())
-                .queryParams("recommendType", EARLIEST_ORDER.getType(), "attendeeNames", attendee.name())
+                .queryParams("recommendType", EARLIEST_ORDER.getType(), "attendeeNames", attendee.name(), "minimumTime", 0)
                 .contentType(ContentType.JSON)
                 .when().get("/api/v1/meetings/{uuid}/recommended-schedules")
                 .then().log().all()

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -163,6 +163,19 @@ class ScheduleControllerTest {
                 .statusCode(HttpStatus.OK.value());
     }
 
+    @DisplayName("추천 약속을 조회시 최소 시간을 입력받지 않아도 동작한다.")
+    @Test
+    void recommendSchedulesWithoutMinTime() {
+        RestAssured.given().log().all()
+                .pathParam("uuid", meeting.getUuid())
+                .queryParam("recommendType", EARLIEST_ORDER.getType())
+                .queryParams("attendeeNames", List.of(attendee.name()))
+                .contentType(ContentType.JSON)
+                .when().get("/api/v1/meetings/{uuid}/recommended-schedules")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
     @DisplayName("추천 약속 조회시 최소 시간이 0보다 작으면 예외가 발생한다.")
     @Test
     void recommendSchedulesIfSmallerThanZero() {

--- a/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
+++ b/backend/src/test/java/kr/momo/controller/schedule/ScheduleControllerTest.java
@@ -154,11 +154,27 @@ class ScheduleControllerTest {
     void recommendSchedules() {
         RestAssured.given().log().all()
                 .pathParam("uuid", meeting.getUuid())
-                .queryParams("recommendType", EARLIEST_ORDER.getType(), "attendeeNames", attendee.name(), "minimumTime", 0)
+                .queryParam("recommendType", EARLIEST_ORDER.getType())
+                .queryParams("attendeeNames", List.of(attendee.name()))
+                .queryParam("minTime", 0)
                 .contentType(ContentType.JSON)
                 .when().get("/api/v1/meetings/{uuid}/recommended-schedules")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value());
+    }
+
+    @DisplayName("추천 약속 조회시 최소 시간이 0보다 작으면 예외가 발생한다.")
+    @Test
+    void recommendSchedulesIfSmallerThanZero() {
+        RestAssured.given().log().all()
+                .pathParam("uuid", meeting.getUuid())
+                .queryParam("recommendType", EARLIEST_ORDER.getType())
+                .queryParams("attendeeNames", List.of(attendee.name()))
+                .queryParam("minTime", -1)
+                .contentType(ContentType.JSON)
+                .when().get("/api/v1/meetings/{uuid}/recommended-schedules")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
     private void createAttendeeSchedule(Attendee attendee) {

--- a/backend/src/test/java/kr/momo/domain/schedule/recommend/CandidateScheduleTest.java
+++ b/backend/src/test/java/kr/momo/domain/schedule/recommend/CandidateScheduleTest.java
@@ -1,7 +1,6 @@
 package kr.momo.domain.schedule.recommend;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
@@ -10,8 +9,6 @@ import java.util.List;
 import kr.momo.domain.attendee.AttendeeGroup;
 import kr.momo.domain.schedule.DateAndTimeslot;
 import kr.momo.domain.timeslot.Timeslot;
-import kr.momo.exception.MomoException;
-import kr.momo.exception.code.ScheduleErrorCode;
 import kr.momo.fixture.AttendeeGroupFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -114,49 +111,6 @@ class CandidateScheduleTest {
 
         // then
         assertThat(mergedSchedules).hasSize(expected);
-    }
-
-    @DisplayName("최소 시간이 최소 크기보다 작으면 예외가 발생한다.")
-    @Test
-    void mergeContinuousTestWhenHasMinSizeLessThan() {
-        // given
-        int givenMinSize = -1;
-        LocalDate today = LocalDate.now();
-        AttendeeGroup group = AttendeeGroupFixture.JAZZ_DAON_BAKEY.create();
-        List<CandidateSchedule> schedules = List.of(
-                // 30분 간격 시간 후보 3개
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0000),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0100),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0200),
-                // 60분 간격 시간 후보 2개
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0300),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0330),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0500),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0530),
-                // 90분 간격 시간 후보 2개
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1000),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1030),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1100),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1200),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1230),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1300),
-                // 120분 간격 시간 후보 1개
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1700),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1730),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1800),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1830),
-                // 150분 간격 시간 후보 1개
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2030),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2100),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2130),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2200),
-                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2230)
-        );
-
-        // when
-        assertThatThrownBy(() -> CandidateSchedule.mergeContinuous(schedules, this::isContinuous, givenMinSize))
-                .isInstanceOf(MomoException.class)
-                .hasMessage(ScheduleErrorCode.INVALID_MIN_TIME.message());
     }
 
     @DisplayName("자정을 포함하여 연속되는 시간의 경우 종료일자는 마지막 시간의 종료일자이다.")

--- a/backend/src/test/java/kr/momo/domain/schedule/recommend/CandidateScheduleTest.java
+++ b/backend/src/test/java/kr/momo/domain/schedule/recommend/CandidateScheduleTest.java
@@ -1,6 +1,7 @@
 package kr.momo.domain.schedule.recommend;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
@@ -9,11 +10,17 @@ import java.util.List;
 import kr.momo.domain.attendee.AttendeeGroup;
 import kr.momo.domain.schedule.DateAndTimeslot;
 import kr.momo.domain.timeslot.Timeslot;
+import kr.momo.exception.MomoException;
+import kr.momo.exception.code.ScheduleErrorCode;
 import kr.momo.fixture.AttendeeGroupFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class CandidateScheduleTest {
+
+    private static final int DEFAULT_MIN_SIZE = 0;
 
     @DisplayName("빈 리스트를 병합할 경우 빈 리스트를 반환한다.")
     @Test
@@ -22,7 +29,9 @@ class CandidateScheduleTest {
         List<CandidateSchedule> schedules = List.of();
 
         // when
-        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(schedules, this::isContinuous);
+        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(
+                schedules, this::isContinuous, DEFAULT_MIN_SIZE
+        );
 
         // then
         assertThat(mergedSchedules).isEmpty();
@@ -43,7 +52,9 @@ class CandidateScheduleTest {
         );
 
         // when
-        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(schedules, this::isContinuous);
+        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(
+                schedules, this::isContinuous, DEFAULT_MIN_SIZE
+        );
 
         // then
         assertAll(
@@ -57,6 +68,95 @@ class CandidateScheduleTest {
                 () -> assertThat(mergedSchedules.get(1).dateTimeInterval().endDateTime())
                         .isEqualTo(LocalDateTime.of(LocalDate.now(), Timeslot.TIME_2230.endTime()))
         );
+    }
+
+    @DisplayName("연속된 시간 길이가 주어진 길이보다 같거나 큰 경우만 병합한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"0,9", "1,9", "2,6", "3,4", "4,2", "5,1"})
+    void mergeContinuousTestWhenHasMinSize(int minSize, int expected) {
+        // given
+        LocalDate today = LocalDate.now();
+        AttendeeGroup group = AttendeeGroupFixture.JAZZ_DAON_BAKEY.create();
+        List<CandidateSchedule> schedules = List.of(
+                // 30분 간격 시간 후보 3개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0000),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0100),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0200),
+                // 60분 간격 시간 후보 2개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0300),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0330),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0500),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0530),
+                // 90분 간격 시간 후보 2개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1000),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1030),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1100),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1200),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1230),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1300),
+                // 120분 간격 시간 후보 1개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1700),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1730),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1800),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1830),
+                // 150분 간격 시간 후보 1개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2030),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2100),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2130),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2200),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2230)
+        );
+
+        // when
+        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(
+                schedules, this::isContinuous, minSize
+        );
+
+        // then
+        assertThat(mergedSchedules).hasSize(expected);
+    }
+
+    @DisplayName("최소 시간이 최소 크기보다 작으면 예외가 발생한다.")
+    @Test
+    void mergeContinuousTestWhenHasMinSizeLessThan() {
+        // given
+        int givenMinSize = -1;
+        LocalDate today = LocalDate.now();
+        AttendeeGroup group = AttendeeGroupFixture.JAZZ_DAON_BAKEY.create();
+        List<CandidateSchedule> schedules = List.of(
+                // 30분 간격 시간 후보 3개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0000),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0100),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0200),
+                // 60분 간격 시간 후보 2개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0300),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0330),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0500),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_0530),
+                // 90분 간격 시간 후보 2개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1000),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1030),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1100),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1200),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1230),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1300),
+                // 120분 간격 시간 후보 1개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1700),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1730),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1800),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_1830),
+                // 150분 간격 시간 후보 1개
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2030),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2100),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2130),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2200),
+                createDiscreteCandidateSchedule(group, today, Timeslot.TIME_2230)
+        );
+
+        // when
+        assertThatThrownBy(() -> CandidateSchedule.mergeContinuous(schedules, this::isContinuous, givenMinSize))
+                .isInstanceOf(MomoException.class)
+                .hasMessage(ScheduleErrorCode.INVALID_MIN_TIME.message());
     }
 
     @DisplayName("자정을 포함하여 연속되는 시간의 경우 종료일자는 마지막 시간의 종료일자이다.")
@@ -75,7 +175,9 @@ class CandidateScheduleTest {
         );
 
         // when
-        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(schedules, this::isContinuous);
+        List<CandidateSchedule> mergedSchedules = CandidateSchedule.mergeContinuous(
+                schedules, this::isContinuous, DEFAULT_MIN_SIZE
+        );
 
         // then
         assertAll(

--- a/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/ScheduleServiceTest.java
@@ -262,7 +262,7 @@ class ScheduleServiceTest {
         scheduleRepository.saveAll(schedules);
 
         RecommendedSchedulesResponse responses = scheduleService.recommendSchedules(
-                movieMeeting.getUuid(), LONG_TERM_ORDER.getType(), List.of(jazz.name(), daon.name())
+                movieMeeting.getUuid(), LONG_TERM_ORDER.getType(), List.of(jazz.name(), daon.name()), 0
         );
 
         assertThat(responses.recommendedSchedules()).containsExactly(
@@ -302,7 +302,7 @@ class ScheduleServiceTest {
         scheduleRepository.saveAll(schedules);
 
         RecommendedSchedulesResponse responses = scheduleService.recommendSchedules(
-                movieMeeting.getUuid(), EARLIEST_ORDER.getType(), List.of(jazz.name(), daon.name())
+                movieMeeting.getUuid(), EARLIEST_ORDER.getType(), List.of(jazz.name(), daon.name()), 0
         );
 
         assertThat(responses.recommendedSchedules()).containsExactly(
@@ -399,7 +399,7 @@ class ScheduleServiceTest {
         scheduleRepository.saveAll(schedules);
 
         RecommendedSchedulesResponse responses = scheduleService.recommendSchedules(
-                movieMeeting.getUuid(), LONG_TERM_ORDER.getType(), List.of(jazz.name(), daon.name())
+                movieMeeting.getUuid(), LONG_TERM_ORDER.getType(), List.of(jazz.name(), daon.name()), 0
         );
 
         assertThat(responses.recommendedSchedules()).containsExactly(

--- a/backend/src/test/java/kr/momo/service/schedule/recommend/ScheduleRecommenderTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/recommend/ScheduleRecommenderTest.java
@@ -203,7 +203,7 @@ class ScheduleRecommenderTest {
         @Test
         void recommendByEachAttendeeSubsetOrderByAttendeeCountAndEarliestTimeWithMinimumTime() {
             // given
-            int givenMinTime = 180;
+            int givenMinTime = 3;
             AttendeeGroup group = new AttendeeGroup(List.of(jazz, pedro, daon, bakey, mark));
             List<CandidateSchedule> expected = List.of(
                     new CandidateSchedule(

--- a/backend/src/test/java/kr/momo/service/schedule/recommend/ScheduleRecommenderTest.java
+++ b/backend/src/test/java/kr/momo/service/schedule/recommend/ScheduleRecommenderTest.java
@@ -37,6 +37,8 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class ScheduleRecommenderTest {
 
+    private static final int DEFAULT_MIN_SIZE = 0;
+
     @Autowired
     private TotalScheduleRecommender totalScheduleRecommender;
 
@@ -74,7 +76,8 @@ class ScheduleRecommenderTest {
 
         AvailableDate todayAvailableDate = availableDateRepository.save(new AvailableDate(today, meeting));
         AvailableDate tomorrowAvailableDate = availableDateRepository.save(
-                new AvailableDate(today.plusDays(1), meeting));
+                new AvailableDate(today.plusDays(1), meeting)
+        );
 
         // jazz: 오늘 0000 ~ 2330 / 내일 0000 ~ 2330
         saveAttendeeSchedule(jazz, todayAvailableDate, createTimeslotRange(Timeslot.TIME_0000, Timeslot.TIME_2330));
@@ -130,19 +133,12 @@ class ScheduleRecommenderTest {
     @Transactional  // TODO: 테스트 코드에서의 @Transactional 사용 논의 필요
     class TotalScheduleRecommenderTest {
 
-        @DisplayName("참여자의 부분집합 별 참여 가능 시간을 구한 뒤, "
+        @DisplayName("참여자의 부분 집합 별 참여 가능 시간을 구한 뒤, "
                 + "(참여자 많은 순, 빠른 시간 순)으로 정렬하고 상위 10개를 추천한다.")
         @Test
         void recommendByEachAttendeeSubsetOrderByAttendeeCountAndEarliestTime() {
             // given
             AttendeeGroup group = new AttendeeGroup(List.of(jazz, pedro, daon, bakey, mark));
-
-            // when
-            List<CandidateSchedule> recommendResult = totalScheduleRecommender.recommend(
-                    group, RecommendedScheduleSortStandard.EARLIEST_ORDER.getType(), MeetingType.DATETIME
-            );
-
-            // then
             List<CandidateSchedule> expected = List.of(
                     new CandidateSchedule(
                             createDateTimeInterval(today, 12, 0, today, 15, 0),
@@ -185,6 +181,67 @@ class ScheduleRecommenderTest {
                             createAttendeeGroup(jazz, daon, mark)
                     )
             );
+
+            // when
+            List<CandidateSchedule> recommendResult = totalScheduleRecommender.recommend(
+                    group,
+                    RecommendedScheduleSortStandard.EARLIEST_ORDER.getType(),
+                    MeetingType.DATETIME,
+                    DEFAULT_MIN_SIZE
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(recommendResult).hasSizeLessThanOrEqualTo(10),
+                    () -> assertThat(recommendResult).containsExactlyElementsOf(expected)
+            );
+        }
+
+        @DisplayName("참여자의 부분 집합 별 참여 가능 시간을 구한 뒤, "
+                + "(참여자 많은 순, 빠른 시간 순)으로 정렬하고 상위 10개를 추천한다."
+                + "최소 시간 보장을 곁들인")
+        @Test
+        void recommendByEachAttendeeSubsetOrderByAttendeeCountAndEarliestTimeWithMinimumTime() {
+            // given
+            int givenMinTime = 180;
+            AttendeeGroup group = new AttendeeGroup(List.of(jazz, pedro, daon, bakey, mark));
+            List<CandidateSchedule> expected = List.of(
+                    new CandidateSchedule(
+                            createDateTimeInterval(today, 12, 0, today, 15, 0),
+                            createAttendeeGroup(jazz, pedro, daon, mark, bakey)
+                    ),
+                    new CandidateSchedule(
+                            createDateTimeInterval(tomorrow, 16, 0, tomorrow, 20, 0),
+                            createAttendeeGroup(jazz, pedro, daon, mark, bakey)
+                    ),
+                    new CandidateSchedule(
+                            createDateTimeInterval(today, 15, 0, today, 18, 30),
+                            createAttendeeGroup(jazz, pedro, daon, bakey)
+                    ),
+                    new CandidateSchedule(
+                            createDateTimeInterval(today, 19, 0, today, 22, 0),
+                            createAttendeeGroup(jazz, pedro, daon, bakey)
+                    ),
+                    new CandidateSchedule(
+                            createDateTimeInterval(tomorrow, 0, 0, tomorrow, 16, 0),
+                            createAttendeeGroup(jazz, daon, bakey, mark)
+                    ),
+                    new CandidateSchedule(
+                            createDateTimeInterval(today, 6, 0, today, 9, 0),
+                            createAttendeeGroup(jazz, pedro, daon)
+                    ),
+                    new CandidateSchedule(
+                            createDateTimeInterval(today, 0, 0, today, 6, 0),
+                            createAttendeeGroup(jazz, daon)
+                    )
+            );
+
+            // when
+            List<CandidateSchedule> recommendResult = totalScheduleRecommender.recommend(
+                    group, RecommendedScheduleSortStandard.EARLIEST_ORDER.getType(), MeetingType.DATETIME, givenMinTime
+            );
+
+            // then
             assertAll(
                     () -> assertThat(recommendResult).hasSizeLessThanOrEqualTo(10),
                     () -> assertThat(recommendResult).containsExactlyElementsOf(expected)
@@ -204,7 +261,10 @@ class ScheduleRecommenderTest {
 
             // when
             List<CandidateSchedule> recommendResult = filteredScheduleRecommender.recommend(
-                    filteredGroup, RecommendedScheduleSortStandard.EARLIEST_ORDER.getType(), MeetingType.DATETIME
+                    filteredGroup,
+                    RecommendedScheduleSortStandard.EARLIEST_ORDER.getType(),
+                    MeetingType.DATETIME,
+                    DEFAULT_MIN_SIZE
             );
 
             // then
@@ -215,7 +275,7 @@ class ScheduleRecommenderTest {
                             expectedGroup
                     ),
                     new CandidateSchedule(
-                            createDateTimeInterval(today, 12, 0, today, 15, 00),
+                            createDateTimeInterval(today, 12, 0, today, 15, 0),
                             expectedGroup
                     ),
                     new CandidateSchedule(


### PR DESCRIPTION
## 관련 이슈

- resolves: #398 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
최소 시간을 보장하는 로직을 추가하였습니다.

### 최소 시간 기준
최소 시간의 경우 ~~30분, 60분, 120분~~ 1시간, 2시간과 같이 ~~30분~~ 1시간 단위로 기준을 잡았습니다.

### 최소 시간 보장 로직
최소 시간 보장하는 로직을 어디에 둘지 고민했는데요. 제가 생각한 최소 요구사항은 아래와 같았습니다.
- sort 기준을 `Duration` 크기의 역순으로 걸고 최소 시간보다 작은 것은 필터링한다.
- 출력할 땐 참가자가 많은 순서대로 정렬 후 시간이 빠른 순(Earliest)으로 정렬한다.

적절한 위치를 고민하다 `CandidateSchedule`내에 `mergeContinuous` 안에 위치시켰습니다.
반복문을 필연적으로 돌아야 하는 곳에서 분기 처리 하는게 효율적이라 생각하였어요 :)

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->
추천 로직 API 에 대해 요구사항이 변경되었습니다!
다만, 기존 로직과 충돌을 방지하기 위해 새로 추가된 `@RequestParam`인  `minTime`에 기본 값을 설정해두었습니다.

## 리뷰 요구사항

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->
전체적으로 로직에서 불합리한 부분이 없는지와 테스트가 부족한 부분이 없는지 확인 부탁 드려요~

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
