### PR TITLE
[ALL] 자바스크립트 번들 파일이 중복으로 생기는 문제 해결

### DIFF
--- a/.github/workflows/frontend-dev-cd.yml
+++ b/.github/workflows/frontend-dev-cd.yml
@@ -80,11 +80,17 @@ jobs:
     env:
       CLOUDFRONT_DISTRIBUTION_ID_DEV: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV}}
     steps:
+      - name: 기존 dist 폴더 내부에 있던 이전 버젼의 dist 폴더 내부 모든 파일을 삭제해요
+        working-directory: ./frontend/
+        run: |
+          rm -rf dist/*
+
       - name: 모모 깃허브 레파지토리 artifacts로 부터 빌드 결과물을 다운받아요 :)
         uses: actions/download-artifact@v4
         with:
           name: momoResources
           path: ./frontend/dist
+
       - name: aws에 배포하고 cloudfront 캐싱을 무효화해요
         working-directory: ./frontend/dist/
         run: |

--- a/.github/workflows/frontend-prod-cd.yml
+++ b/.github/workflows/frontend-prod-cd.yml
@@ -84,11 +84,17 @@ jobs:
     env:
       CLOUDFRONT_DISTRIBUTION_ID_PROD: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD}}
     steps:
+      - name: 기존 dist 폴더 내부에 있던 이전 버젼의 dist 폴더 내부 모든 파일을 삭제해요
+        working-directory: ./frontend/
+        run: |
+          rm -rf dist/*
+
       - name: 모모 깃허브 레파지토리 artifacts로 부터 빌드 결과물을 다운받아요 :)
         uses: actions/download-artifact@v4
         with:
           name: momoResources
           path: ./frontend/dist
+
       - name: aws에 배포하고 cloudfront 캐싱을 무효화해요
         working-directory: ./frontend/dist/
         run: |


### PR DESCRIPTION
## 관련 이슈

- resolves: #407 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

**🚨 dev, prod 모두 배포할 때마다 같은 자바스크립트 파일이 중복으로 업로드 되는 문제 발생**
**🚨 prod에 배포할 때마다, dev에 있는 자바스크립트 파일을 계속해서 가져오는 문제 발생**

<img width="797" alt="image" src="https://github.com/user-attachments/assets/f3f3432f-1b14-44f6-ac14-8d64c3ad693a">

원인은, dev와 prod 배포 모두 동일한 인스턴스를 사용하고, 같은 폴더인 frontend/dist를 사용하기 때문이었습니다. 해당 폴더를 배포 자동화를 위해 사용할 때마다 자바스크립트 파일들이 쌓이고, 해당 파일들을 aws와 싱크를 맞춥니다. 이 때, dev에 배포하든 prod에 배포하든 서로의 배포에 영향을 주게 됩니다. 그래서 깃허브 임시 저장소(artifacts)에 있는 리소스들을 다운로드 받기 전 이전 버전 배포를 위해 사용되었던 dist 폴더 내부 모든 파일들을 삭제하도록 하는 step을 추가했습니다. 아래는 추가된 step입니다.

```sh
      - name: 기존 dist 폴더 내부에 있던 이전 버젼의 dist 폴더 내부 모든 파일을 삭제해요
        working-directory: ./frontend/
        run: |
          rm -rf dist/*
```

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
