### PR TITLE
[BE] 프로덕션 서버 무중단 배포 환경 구축

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -109,10 +109,10 @@ jobs:
       - name: docker pull
         run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/momo-api-prod
 
-      # 2. 실행 컨테이너 중 app 서비스만 재시작
-      - name: Restart app service
-        run: docker compose -f $HOME/security/docker-compose-prod.yml restart app --no-deps
+      # 2. 블루그린 배포 스크립트 실행
+      - name: Launch Blue-Green Deployment
+        run: chmod +x $HOME/security/deploy.sh; $HOME/security/deploy.sh
 
-      # 3. 미사용 이미지를 정리
+      # 3. 미사용 이미지 정리
       - name: delete old docker image
         run: docker system prune -f


### PR DESCRIPTION
## 관련 이슈

- resolves: #412 

## 작업 내용

프로덕션 서버(`prod-a`, `prod-b`)에 무중단 배포를 적용합니다.
nginx와 docker 컨테이너를 활용한 Blue/Green 전략을 사용하며, 인스턴스 내에서 컨테이너 두 개를 실행하고, 새로운 컨테이너에 이상이 없다면 `proxy_pass`를 전환시킨 후 기존 컨테이너를 종료하는 형태로 동작합니다.

```bash
echo "0. 현재 실행 중인 컨테이너 목록 확인"
show_docker_ps

echo "1. Green 포트 결정"
determine_port

echo "2. Green 컨테이너 실행"
run_green_container $new_was_port $new_actuator_port

echo "3. Green Health Check"
green_health_check $new_actuator_port

echo "4. nginx 포트 재설정 -> nginx reload"
nginx_reload $new_was_port $new_actuator_port $past_was_port $past_actuator_port

echo "5. Blue 컨테이너 stop -> rm"
stop_blue_container $past_was_port

echo "6. 배포 완료"
finalize $new_was_port
```
전체 플로우는 위와 같으며, 스크립트 상세 구현은 서브모듈을 참고해 주세요.


## 특이 사항

`Connection: keep-alive`에서 nginx가 TCP 커넥션을 처리하는 방식 때문에 `nginx reload` 시 약 0.1~0.2초의 다운타임이 발생합니다. 서비스 특성 상 이정도의 다운타임이 크리티컬한 장애요소가 되지는 않지만, 진정한 '무중단' 배포로 볼 수 없다는 시각 역시 존재합니다.
[nginx worker를 튜닝하여 다운타임을 0.0초대로 감소시킨 사례](https://haon.blog/haon/infra/ci-cd/downtime-try/)가 존재하긴 하지만, 완전히 제로 다운타임을 만드는 것은 nginx만을 가지고는 불가능해 보입니다.

현재 ELB를 사용하여 프로덕션 인스턴스가 이중화되어 있으므로, 한쪽의 배포가 진행되는 찰나의 순간동안 로드밸런서의 라우팅을 제어하여 (롤링+블루그린을 혼합한 형태가 되겠네요🤔) 구현이 가능할 것 같긴 한데 아래와 같은 고민이 좀 더 필요합니다.
- CSP 기능에 배포 프로세스가 종속됨
- ELB에서 대상 그룹을 수정했을 때 기존에 연결되어 있던 Keepalive TCP Connection이 Graceful Shutdown 되는지 여부 확인 필요

> [!NOTE]
> 현재는 배포 이후 기존의 컨테이너를 바로 종료시키므로, 블루그린 배포의 이점 중 하나인 빠른 롤백을 100% 활용하지는 못하고 있습니다.
> 이후 자동 롤백의 기준과 구현 방향을 확정지은 후, 스크립트 수정이 필요해 보입니다.

ref: https://trac.nginx.org/nginx/ticket/1022#comment:1


## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
