### PR TITLE
[FE] 약속 생성 확인 모달 복구

### DIFF
--- a/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/MeetingCreationConfirmModal.styles.ts
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/MeetingCreationConfirmModal.styles.ts
@@ -1,0 +1,32 @@
+import { css } from '@emotion/react';
+
+import theme from '@styles/theme';
+
+export const s_descriptionContainer = css`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  strong {
+    ${theme.typography.captionBold}
+    color: ${theme.colors.primary}
+  }
+`;
+
+export const s_description = css`
+  ${theme.typography.captionMedium}
+  display: flex;
+  gap: 0.8rem;
+`;
+
+export const s_availableDateDescription = css`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const s_availableDatesContainer = css`
+  ${theme.typography.captionMedium}
+  display: grid;
+  grid-template-columns: 2fr 5fr;
+`;

--- a/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/index.tsx
@@ -62,7 +62,7 @@ export default function MeetingCreationConfirmModal({
                 <h3>
                   {year}년 {month}월
                 </h3>
-                <div>{dates.join(', ')}</div>
+                <p>{dates.join(', ')}</p>
               </div>
             );
           })}

--- a/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/index.tsx
@@ -1,0 +1,73 @@
+import ConfirmModal from '@components/_common/Modal/ConfirmModal';
+
+import groupDates from '@utils/groupDates';
+
+import {
+  s_availableDateDescription,
+  s_availableDatesContainer,
+  s_description,
+  s_descriptionContainer,
+} from './MeetingCreationConfirmModal.styles';
+
+interface MeetingCreationConfirmModalProps {
+  isModalOpen: boolean;
+  onModalClose: () => void;
+  onModalConfirmButtonClick: () => void;
+  meetingName: string;
+  hostName: string;
+  selectedDates: string[];
+  startTime: string;
+  endTime: string;
+  isOnlyDaysOptionChecked: boolean;
+}
+
+export default function MeetingCreationConfirmModal({
+  isModalOpen,
+  onModalClose,
+  onModalConfirmButtonClick,
+  meetingName,
+  hostName,
+  selectedDates,
+  startTime,
+  endTime,
+  isOnlyDaysOptionChecked,
+}: MeetingCreationConfirmModalProps) {
+  return (
+    <ConfirmModal
+      isOpen={isModalOpen}
+      onClose={onModalClose}
+      onConfirm={onModalConfirmButtonClick}
+      position="center"
+      size="small"
+      title="입력하신 약속 정보를 확인해주세요."
+    >
+      <div css={s_descriptionContainer}>
+        <p css={s_description}>
+          <strong>약속명</strong> {meetingName}
+        </p>
+        <p css={s_description}>
+          <strong>주최자</strong> {hostName}
+        </p>
+        {!isOnlyDaysOptionChecked && (
+          <p css={s_description}>
+            <strong>약속 시간</strong> {startTime} ~ {endTime}
+          </p>
+        )}
+        <div css={s_availableDateDescription}>
+          <strong>가능 날짜</strong>
+          {groupDates(selectedDates).map(([monthYear, dates]) => {
+            const [year, month] = monthYear.split('-');
+            return (
+              <div css={s_availableDatesContainer} key={monthYear}>
+                <h3>
+                  {year}년 {month}월
+                </h3>
+                <span>{dates.join(', ')}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </ConfirmModal>
+  );
+}

--- a/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingCreationConfirmModal/index.tsx
@@ -62,7 +62,7 @@ export default function MeetingCreationConfirmModal({
                 <h3>
                   {year}년 {month}월
                 </h3>
-                <span>{dates.join(', ')}</span>
+                <div>{dates.join(', ')}</div>
               </div>
             );
           })}

--- a/frontend/src/pages/CreateMeetingPage/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/index.tsx
@@ -2,15 +2,21 @@ import MeetingDateTime from '@pages/CreateMeetingPage/components/MeetingDateTime
 import MeetingHostInfo from '@pages/CreateMeetingPage/components/MeetingHostInfo';
 import MeetingName from '@pages/CreateMeetingPage/components/MeetingName';
 
+import useConfirmModal from '@hooks/useConfirmModal/useConfirmModal';
 import useCreateMeeting from '@hooks/useCreateMeeting/useCreateMeeting';
 import useFunnel from '@hooks/useFunnel/useFunnel';
 
 import { CREATE_MEETING_STEPS, meetingStepValues } from '@constants/meeting';
 
+import MeetingCreationConfirmModal from './components/MeetingCreationConfirmModal';
+
 type Steps = typeof meetingStepValues;
 
 export default function CreateMeetingPage() {
+  const { isConfirmModalOpen, onToggleConfirmModal } = useConfirmModal();
+
   const [setStep, Funnel] = useFunnel<Steps>(meetingStepValues, '약속이름');
+
   const {
     meetingNameInput,
     isMeetingNameInvalid,
@@ -25,31 +31,44 @@ export default function CreateMeetingPage() {
   } = useCreateMeeting();
 
   return (
-    <Funnel>
-      <Funnel.Step name={CREATE_MEETING_STEPS.meetingName}>
-        <MeetingName
-          meetingNameInput={meetingNameInput}
-          isMeetingNameInvalid={isMeetingNameInvalid}
-          onNextStep={() => setStep(CREATE_MEETING_STEPS.meetingHostInfo)}
-        />
-      </Funnel.Step>
-      <Funnel.Step name={CREATE_MEETING_STEPS.meetingHostInfo}>
-        <MeetingHostInfo
-          hostNickNameInput={hostNickNameInput}
-          hostPasswordInput={hostPasswordInput}
-          isHostInfoInvalid={isHostInfoInvalid}
-          onNextStep={() => setStep(CREATE_MEETING_STEPS.meetingDateTime)}
-        />
-      </Funnel.Step>
-      <Funnel.Step name={CREATE_MEETING_STEPS.meetingDateTime}>
-        <MeetingDateTime
-          meetingDateInput={meetingDateInput}
-          meetingTimeInput={meetingTimeInput}
-          meetingTypeInput={meetingTypeInput}
-          isCreateMeetingFormInvalid={isCreateMeetingFormInvalid}
-          onMeetingCreateButtonClick={handleMeetingCreateButtonClick}
-        />
-      </Funnel.Step>
-    </Funnel>
+    <>
+      <Funnel>
+        <Funnel.Step name={CREATE_MEETING_STEPS.meetingName}>
+          <MeetingName
+            meetingNameInput={meetingNameInput}
+            isMeetingNameInvalid={isMeetingNameInvalid}
+            onNextStep={() => setStep(CREATE_MEETING_STEPS.meetingHostInfo)}
+          />
+        </Funnel.Step>
+        <Funnel.Step name={CREATE_MEETING_STEPS.meetingHostInfo}>
+          <MeetingHostInfo
+            hostNickNameInput={hostNickNameInput}
+            hostPasswordInput={hostPasswordInput}
+            isHostInfoInvalid={isHostInfoInvalid}
+            onNextStep={() => setStep(CREATE_MEETING_STEPS.meetingDateTime)}
+          />
+        </Funnel.Step>
+        <Funnel.Step name={CREATE_MEETING_STEPS.meetingDateTime}>
+          <MeetingDateTime
+            meetingDateInput={meetingDateInput}
+            meetingTimeInput={meetingTimeInput}
+            meetingTypeInput={meetingTypeInput}
+            isCreateMeetingFormInvalid={isCreateMeetingFormInvalid}
+            onMeetingCreateButtonClick={onToggleConfirmModal}
+          />
+        </Funnel.Step>
+      </Funnel>
+      <MeetingCreationConfirmModal
+        isModalOpen={isConfirmModalOpen}
+        onModalClose={onToggleConfirmModal}
+        onModalConfirmButtonClick={handleMeetingCreateButtonClick}
+        meetingName={meetingNameInput.value}
+        hostName={hostNickNameInput.value}
+        selectedDates={Array.from(meetingDateInput.selectedDates)}
+        startTime={meetingTimeInput.startTime.value}
+        endTime={meetingTimeInput.endTime.value}
+        isOnlyDaysOptionChecked={meetingTypeInput.isChecked}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## 관련 이슈
- resolves: #406 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->
<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->
[약속 생성 시 퍼널 패턴을 도입하는 과정](https://github.com/woowacourse-teams/2024-momo/pull/356)에서 사라졌던 '약속 생성 확인 모달'을 복구하였습니다.
'약속 생성 확인 모달'은 `CreateMeetingPage` 하위 컴포넌트(`MeetingCreationConfirmModal`)로 분리하였습니다. 

<div align="center">
  <img width="360" alt="약속 생성 확인 모달" src="https://github.com/user-attachments/assets/8a80f0ba-40af-4bc8-9a77-cce3584c3797">
</div>

## 특이 사항
<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
