### PR TITLE
[FE] 인풋 컴포넌트 디자인 수정 및 로그인 페이지 디자인 수정

### DIFF
--- a/frontend/src/components/FloatingInput/FloatingInput.stories.tsx
+++ b/frontend/src/components/FloatingInput/FloatingInput.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import FloatingInput from '.';
+
+const meta = {
+  title: 'Components/Inputs/FloatingInput',
+  component: FloatingInput,
+  argTypes: {
+    label: { control: 'text' },
+    isError: { control: 'boolean' },
+  },
+} satisfies Meta<typeof FloatingInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: '낙타해리빙봉',
+    placeholder: '송재석최현웅김윤경',
+    isError: false,
+  },
+};

--- a/frontend/src/components/FloatingInput/FloatingInput.styles.ts
+++ b/frontend/src/components/FloatingInput/FloatingInput.styles.ts
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react';
+
+import theme from '@styles/theme';
+
+export const s_floatingLabelContainer = css`
+  position: relative;
+  display: inline-block;
+  width: 100%;
+`;
+
+export const s_floatingLabelInput = (isError: boolean) => css`
+  appearance: none;
+  box-shadow: ${isError ? `0 0 0 0.1rem #EB1E1E` : `0 0 0 0.1rem #71717a`};
+  transition: box-shadow 0.3s;
+
+  &::placeholder {
+    color: #71717a;
+  }
+
+  &:focus {
+    box-shadow: ${isError
+      ? `0 0 0 0.1rem #EB1E1E`
+      : `0 0 0 0.1rem ${theme.colors.pink.mediumLight}`};
+  }
+`;
+
+const getLabelTextColor = (isFocused: boolean, isError: boolean): string => {
+  if (isError) return '#EB1E1E';
+
+  if (isFocused) return theme.colors.pink.medium;
+
+  return '#71717a';
+};
+
+export const s_floatingLabel = (isFocused: boolean, isError: boolean) => css`
+  position: absolute;
+  top: 0.4rem;
+  left: 1em;
+
+  ${theme.typography.captionMedium};
+
+  color: ${getLabelTextColor(isFocused, isError)};
+
+  background: transparent;
+
+  transition: color 0.3s;
+`;

--- a/frontend/src/components/FloatingInput/index.tsx
+++ b/frontend/src/components/FloatingInput/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+import type { InputProps } from '@components/_common/Input';
+import Input from '@components/_common/Input';
+
+import {
+  s_floatingLabel,
+  s_floatingLabelContainer,
+  s_floatingLabelInput,
+} from './FloatingInput.styles';
+
+interface FloatingInputProps extends InputProps {
+  label: string;
+  isError: boolean;
+}
+export default function FloatingInput({
+  label,
+  placeholder,
+  isError,
+  ...props
+}: FloatingInputProps) {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const focus = () => setIsFocused(true);
+  const blur = () => setIsFocused(false);
+
+  return (
+    <div css={s_floatingLabelContainer}>
+      <label css={s_floatingLabel(isFocused, isError)} htmlFor={label}>
+        {label}
+      </label>
+      <Input
+        variant="floating"
+        css={s_floatingLabelInput(isError)}
+        placeholder={placeholder}
+        id={label}
+        onFocus={focus}
+        onBlur={blur}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/MeetingCalendar/Date/Date.styles.ts
+++ b/frontend/src/components/MeetingCalendar/Date/Date.styles.ts
@@ -121,7 +121,7 @@ export const s_rangeStart = (isAllRangeSelected: boolean) => css`
 
     position: absolute;
     top: 0;
-    right: 0.4px;
+    right: 0.02rem;
     bottom: 0;
 
     width: 20%;

--- a/frontend/src/components/ScrollBlock/index.tsx
+++ b/frontend/src/components/ScrollBlock/index.tsx
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from 'react';
+import { useEffect, useRef } from 'react';
+
+export default function ScrollBlock({ children }: PropsWithChildren) {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+    };
+
+    // 터치 이벤트를 사용해서 스크롤을 할 경우, 해당 스크롤을 막는다는 것을 브라우저에게 명시적으로 알려주기 위해서 passive 속성 추가(@해리)
+    document.addEventListener('touchmove', handleTouchMove, { passive: false });
+
+    return () => {
+      document.removeEventListener('touchmove', handleTouchMove);
+    };
+  }, []);
+
+  return <div ref={contentRef}>{children}</div>;
+}

--- a/frontend/src/components/_common/Buttons/BottomFixedButton/BottomFixedButton.styles.ts
+++ b/frontend/src/components/_common/Buttons/BottomFixedButton/BottomFixedButton.styles.ts
@@ -6,8 +6,10 @@ export const s_bottomFixedStyles = css`
 
   /* 버튼 컴포넌트의 full variants를 사용하려고 했으나 6rem보다 height값이 작아 직접 높이를 정의했어요(@해리) 
      full 버튼에 이미 의존하고 있는 컴포넌트들이 많아서 높이를 full 스타일을 변경할 수는 없었습니다.
+     
+     버튼의 높이가 너무 높다는 피드백을 반영하기 위해서 높이 수정 5.2rem(@해리)
   */
-  height: 6rem;
+  height: 5.2rem;
   box-shadow: 0 -4px 4px rgb(0 0 0 / 25%);
 `;
 

--- a/frontend/src/components/_common/Field/Field.styles.ts
+++ b/frontend/src/components/_common/Field/Field.styles.ts
@@ -7,6 +7,7 @@ export const s_field = css`
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+  margin-bottom: 1.2rem;
 `;
 
 export const s_label = css`

--- a/frontend/src/components/_common/Field/index.tsx
+++ b/frontend/src/components/_common/Field/index.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from 'react';
 
+import FloatingInput from '@components/FloatingInput';
+
+import Text from '../Text';
 import {
   s_description,
   s_errorMessage,
@@ -16,6 +19,14 @@ const Field = ({ children }: FieldProps) => {
   return <div css={s_field}>{children}</div>;
 };
 
+interface FieldTitleProps {
+  title: string;
+}
+
+const FieldTitle = ({ title }: FieldTitleProps) => {
+  return <Text typo="subTitleBold">{title}</Text>;
+};
+
 interface FieldLabelProps {
   id: string;
   labelText: string;
@@ -29,6 +40,7 @@ const FieldLabel = ({ id, labelText }: FieldLabelProps) => (
 
 interface FieldDescriptionProps {
   description?: string;
+  accentText?: string;
 }
 
 const FieldDescription = ({ description }: FieldDescriptionProps) =>
@@ -44,8 +56,10 @@ const FieldErrorMessage = ({ errorMessage }: FieldErrorMessageProps) => (
   </div>
 );
 
+Field.Title = FieldTitle;
 Field.Label = FieldLabel;
 Field.Description = FieldDescription;
 Field.ErrorMessage = FieldErrorMessage;
+Field.FloatingInput = FloatingInput;
 
 export default Field;

--- a/frontend/src/components/_common/Input/Input.styles.ts
+++ b/frontend/src/components/_common/Input/Input.styles.ts
@@ -4,9 +4,8 @@ import theme from '@styles/theme';
 
 const baseInputStyle = css`
   width: 100%;
-  height: 4.4rem;
-  padding: 0.8rem;
-  outline-color: ${theme.colors.primary};
+  height: 4.8rem;
+  outline: none;
   ${theme.typography.bodyMedium}
 `;
 
@@ -18,5 +17,15 @@ export const s_input = {
     ${baseInputStyle}
     border: none;
     outline: none;
+  `,
+  floating: css`
+    padding-top: 1.6rem; /* 텍스트를 아래로 내리기 위해 top padding을 더 줌 (@해리) */
+    padding-left: 1.2rem;
+
+    color: #71717a;
+
+    border: none;
+    ${baseInputStyle}
+    border-radius: 1.2rem;
   `,
 };

--- a/frontend/src/components/_common/Input/index.tsx
+++ b/frontend/src/components/_common/Input/index.tsx
@@ -2,12 +2,13 @@ import type { InputHTMLAttributes } from 'react';
 
 import { s_input } from './Input.styles';
 
-export type InputVariant = 'default' | 'transparent';
+export type InputVariant = 'default' | 'transparent' | 'floating';
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   variant?: InputVariant;
+  isError?: boolean;
 }
 
 export default function Input({ variant = 'default', type = 'text', ...props }: InputProps) {
-  return <input css={s_input[variant]} type={type} {...props} />;
+  return <input css={s_input[variant]} type={type} spellCheck={false} {...props} />;
 }

--- a/frontend/src/constants/button.ts
+++ b/frontend/src/constants/button.ts
@@ -1,0 +1,5 @@
+export const MEETING_BUTTON_TEXTS = {
+  create: '약속 생성하기',
+  next: '다음',
+  register: '등록하러 가기',
+};

--- a/frontend/src/constants/inputFields.ts
+++ b/frontend/src/constants/inputFields.ts
@@ -10,7 +10,34 @@ export const INPUT_RULES = {
 
 export const FIELD_DESCRIPTIONS = {
   meetingName: '약속 이름은 1~10자 사이로 입력해 주세요.',
+  nickname: '1~5자 사이로 입력해 주세요.',
+  password: '4자리 숫자로 입력해 주세요.',
+  date: '날짜를 하나씩 클릭해 여러 날짜를 선택하거나\n시작일과 종료일을 클릭해 사이의 모든 날짜를 선택해 보세요',
+};
+
+export const FIELD_TITLES = {
+  meetingName: '약속 정보 입력',
+  meetingHostInfo: '약속 주최자 정보 입력',
+  meetingDateTime: '약속 후보 날짜 선택',
+  meetingTimeRange: '약속 시간 범위 선택',
+  attendeeLogin: '내 정보 입력',
+};
+
+export const FIELD_LABELS = {
+  meetingName: '약속 이름',
+  nickname: '닉네임',
+  password: '비밀번호',
+  onlyDate: '날짜만 선택할래요',
+};
+
+export const FIELD_PLACEHOLDERS = {
+  meetingName: '10자 이내의 약속 이름 입력',
+  nickname: '5자 이내의 약속 닉네임 입력',
+  password: '4자리 숫자 입력',
+};
+
+export const FIELD_ERROR_MESSAGES = {
+  meetingName: '약속 이름은 1~10자 사이로 입력해 주세요.',
   nickname: '닉네임은 1~5자 사이로 입력해 주세요.',
   password: '비밀번호는 4자리 숫자로 입력해 주세요.',
-  date: '날짜를 하나씩 클릭해 여러 날짜를 선택하거나\n시작일과 종료일을 클릭해 사이의 모든 날짜를 선택해 보세요',
 };

--- a/frontend/src/constants/toasts.ts
+++ b/frontend/src/constants/toasts.ts
@@ -1,0 +1,3 @@
+export const TOAST_MESSAGES = {
+  OUT_OF_ONE_YEAR_RANGE: '최대 1년뒤의 약속만 생성할 수 있어요',
+};

--- a/frontend/src/hooks/useAttendeeLogin/useAttendeeLogin.ts
+++ b/frontend/src/hooks/useAttendeeLogin/useAttendeeLogin.ts
@@ -1,0 +1,60 @@
+import { useParams } from 'react-router-dom';
+
+import useInput from '@hooks/useInput/useInput';
+
+import { usePostLoginMutation } from '@stores/servers/user/mutations';
+
+import { FIELD_ERROR_MESSAGES, INPUT_FIELD_PATTERN } from '@constants/inputFields';
+
+const useAttendeeLogin = () => {
+  const { uuid } = useParams<{ uuid: string }>();
+  const { mutate: postLoginMutate } = usePostLoginMutation();
+
+  const attendeeNameInput = useInput({
+    pattern: INPUT_FIELD_PATTERN.nickname,
+    errorMessage: FIELD_ERROR_MESSAGES.nickname,
+  });
+  const isAttendeeNameError = attendeeNameInput.errorMessage !== null;
+  const attendeeNameField = { ...attendeeNameInput, isError: isAttendeeNameError };
+
+  const attendeePasswordInput = useInput({
+    pattern: INPUT_FIELD_PATTERN.password,
+    errorMessage: FIELD_ERROR_MESSAGES.password,
+  });
+  const isAttendeePasswordError = attendeePasswordInput.errorMessage !== null;
+  const attendeePasswordField = { ...attendeePasswordInput, isError: isAttendeePasswordError };
+
+  const isFormValid = () => {
+    const hasLoginFormError = isAttendeeNameError || isAttendeePasswordError;
+
+    if (hasLoginFormError) {
+      return false;
+    }
+
+    const requiredFields = [attendeeNameInput.value, attendeePasswordInput.value];
+    const isAllFieldsFilled = requiredFields.every((field) => field !== '');
+
+    return isAllFieldsFilled;
+  };
+
+  const handleLoginButtonClick = async () => {
+    if (!uuid) {
+      console.error('UUID is missing');
+      return;
+    }
+
+    postLoginMutate({
+      uuid,
+      request: { attendeeName: attendeeNameInput.value, password: attendeePasswordInput.value },
+    });
+  };
+
+  return {
+    attendeeNameField,
+    attendeePasswordField,
+    isFormValid,
+    handleLoginButtonClick,
+  };
+};
+
+export default useAttendeeLogin;

--- a/frontend/src/hooks/useCalendar/useCalendar.ts
+++ b/frontend/src/hooks/useCalendar/useCalendar.ts
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import type { MonthlyDays } from 'types/calendar';
 
-import { getMonth, getYear } from '@utils/date';
+import useToast from '@hooks/useToast/useToast';
+
+import { getFullDate, getMonth, getYear } from '@utils/date';
+
+import { TOAST_MESSAGES } from '@constants/toasts';
 
 import { getMonthlyCalendarDate } from './useCalendar.utils';
 
@@ -23,9 +27,11 @@ interface useCalendarReturn {
 }
 
 const TODAY = new Date();
+const ONE_YEAR_LATER = getFullDate(new Date(getYear(TODAY) + 1, getMonth(TODAY)));
 
 const useCalendar = (): useCalendarReturn => {
   const [currentFullDate, setCurrentFullDate] = useState(new Date());
+  const { addToast } = useToast();
 
   const currentYear = getYear(currentFullDate);
   const currentMonth = getMonth(currentFullDate);
@@ -36,6 +42,17 @@ const useCalendar = (): useCalendarReturn => {
   };
 
   const moveToNextMonth = () => {
+    const fullDate = getFullDate(currentFullDate);
+
+    if (fullDate >= ONE_YEAR_LATER) {
+      addToast({
+        message: TOAST_MESSAGES.OUT_OF_ONE_YEAR_RANGE,
+        type: 'warning',
+        duration: 2000,
+      });
+      return;
+    }
+
     setCurrentFullDate(new Date(currentYear, currentMonth + 1));
   };
 

--- a/frontend/src/hooks/useCreateMeeting/useCreateMeeting.ts
+++ b/frontend/src/hooks/useCreateMeeting/useCreateMeeting.ts
@@ -6,7 +6,7 @@ import useTimeRangeDropdown from '@hooks/useTimeRangeDropdown/useTimeRangeDropdo
 
 import { usePostMeetingMutation } from '@stores/servers/meeting/mutations';
 
-import { FIELD_DESCRIPTIONS, INPUT_FIELD_PATTERN, INPUT_RULES } from '@constants/inputFields';
+import { FIELD_ERROR_MESSAGES, INPUT_FIELD_PATTERN, INPUT_RULES } from '@constants/inputFields';
 
 const checkInputInvalid = (value: string, errorMessage: string | null) =>
   value.length < INPUT_RULES.minimumLength || errorMessage !== null;
@@ -14,7 +14,7 @@ const checkInputInvalid = (value: string, errorMessage: string | null) =>
 const useCreateMeeting = () => {
   const meetingNameInput = useInput({
     pattern: INPUT_FIELD_PATTERN.meetingName,
-    errorMessage: FIELD_DESCRIPTIONS.meetingName,
+    errorMessage: FIELD_ERROR_MESSAGES.meetingName,
   });
   const isMeetingNameInvalid = checkInputInvalid(
     meetingNameInput.value,
@@ -23,11 +23,11 @@ const useCreateMeeting = () => {
 
   const hostNickNameInput = useInput({
     pattern: INPUT_FIELD_PATTERN.nickname,
-    errorMessage: FIELD_DESCRIPTIONS.nickname,
+    errorMessage: FIELD_ERROR_MESSAGES.nickname,
   });
   const hostPasswordInput = useInput({
     pattern: INPUT_FIELD_PATTERN.password,
-    errorMessage: FIELD_DESCRIPTIONS.password,
+    errorMessage: FIELD_ERROR_MESSAGES.password,
   });
   const isHostInfoInvalid =
     checkInputInvalid(hostNickNameInput.value, hostNickNameInput.errorMessage) ||

--- a/frontend/src/pages/AttendeeLoginPage/AttendeeLoginPage.styles.ts
+++ b/frontend/src/pages/AttendeeLoginPage/AttendeeLoginPage.styles.ts
@@ -3,22 +3,13 @@ import { css } from '@emotion/react';
 export const s_container = css`
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  align-items: center;
-  justify-content: center;
-
-  height: calc(100vh - 8.4rem);
-  padding: 0 2rem;
+  row-gap: 0.4rem;
+  height: 100%;
 `;
 
 export const s_inputContainer = css`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-
+  justify-content: center;
   width: 100%;
-  padding: 1.6rem;
-
-  background-color: #f7dacb;
-  border-radius: 0.5rem;
 `;

--- a/frontend/src/pages/AttendeeLoginPage/index.tsx
+++ b/frontend/src/pages/AttendeeLoginPage/index.tsx
@@ -1,102 +1,76 @@
-import { useParams } from 'react-router-dom';
-
+import FloatingLabelInput from '@components/FloatingInput';
+import ScrollBlock from '@components/ScrollBlock';
 import { Button } from '@components/_common/Buttons/Button';
 import Field from '@components/_common/Field';
-import Input from '@components/_common/Input';
+import Text from '@components/_common/Text';
 
-import useInput from '@hooks/useInput/useInput';
+import useAttendeeLogin from '@hooks/useAttendeeLogin/useAttendeeLogin';
 
-import { usePostLoginMutation } from '@stores/servers/user/mutations';
-
-import { FIELD_DESCRIPTIONS, INPUT_FIELD_PATTERN } from '@constants/inputFields';
+import { MEETING_BUTTON_TEXTS } from '@constants/button';
+import { FIELD_LABELS, FIELD_PLACEHOLDERS, FIELD_TITLES } from '@constants/inputFields';
 
 import { s_container, s_inputContainer } from './AttendeeLoginPage.styles';
 
 export default function AttendeeLoginPage() {
-  const { uuid } = useParams<{ uuid: string }>();
-  const { mutate: postLoginMutate } = usePostLoginMutation();
+  const { attendeeNameField, attendeePasswordField, handleLoginButtonClick, isFormValid } =
+    useAttendeeLogin();
 
   const {
     value: attendeeName,
     onValueChange: handleAttendeeNameChange,
     errorMessage: attendeeNameErrorMessage,
-  } = useInput({
-    pattern: INPUT_FIELD_PATTERN.nickname,
-    errorMessage: FIELD_DESCRIPTIONS.nickname,
-  });
+    isError: isAttendeeNameError,
+  } = attendeeNameField;
 
   const {
     value: attendeePassword,
     onValueChange: handleAttendeePasswordChange,
     errorMessage: attendeePasswordErrorMessage,
-  } = useInput({
-    pattern: INPUT_FIELD_PATTERN.password,
-    errorMessage: FIELD_DESCRIPTIONS.password,
-  });
-
-  const isFormValid = () => {
-    const errorMessages = [attendeeNameErrorMessage, attendeePasswordErrorMessage];
-    const hasErrors = errorMessages.some((errorMessage) => errorMessage !== null);
-
-    if (hasErrors) {
-      return false;
-    }
-
-    const requiredFields = [attendeeName, attendeePassword];
-    const isAllFieldsFilled = requiredFields.every((field) => field !== '');
-
-    return isAllFieldsFilled;
-  };
-
-  const handleLoginButtonClick = async () => {
-    if (!uuid) {
-      console.error('UUID is missing');
-      return;
-    }
-
-    postLoginMutate({
-      uuid,
-      request: { attendeeName, password: attendeePassword },
-    });
-  };
+    isError: isAttendeePasswordError,
+  } = attendeePasswordField;
 
   return (
-    <div css={s_container}>
-      <div css={s_inputContainer}>
-        <Field>
-          <Field.Label id="닉네임" labelText="닉네임" />
-          <Field.Description description={FIELD_DESCRIPTIONS.nickname} />
-          <Input
-            placeholder="닉네임을 입력하세요."
-            value={attendeeName}
-            onChange={handleAttendeeNameChange}
-          />
-          <Field.ErrorMessage errorMessage={attendeeNameErrorMessage} />
-        </Field>
+    <ScrollBlock>
+      <div css={s_container}>
+        <div css={s_inputContainer}>
+          <Field>
+            <Field.Title title={FIELD_TITLES.attendeeLogin} />
 
-        <Field>
-          <Field.Label id="비밀번호" labelText="비밀번호" />
-          <Field.Description description={FIELD_DESCRIPTIONS.password} />
-          <Input
-            type="number"
-            id="비밀번호"
-            inputMode="numeric"
-            pattern="[0-9]*"
-            placeholder="비밀번호를 입력하세요."
-            value={attendeePassword}
-            onChange={handleAttendeePasswordChange}
-          />
-          <Field.ErrorMessage errorMessage={attendeePasswordErrorMessage} />
-        </Field>
+            <Text typo="captionBold" variant="caption">
+              약속에서 사용할 <Text.Accent text="닉네임과 비밀번호" />를 입력해 주세요
+            </Text>
+            <FloatingLabelInput
+              label={FIELD_LABELS.nickname}
+              placeholder={FIELD_PLACEHOLDERS.nickname}
+              value={attendeeName}
+              onChange={handleAttendeeNameChange}
+              autoComplete="off"
+              isError={isAttendeeNameError}
+              autoFocus
+            />
+            <FloatingLabelInput
+              label={FIELD_LABELS.password}
+              placeholder={FIELD_PLACEHOLDERS.password}
+              value={attendeePassword}
+              onChange={handleAttendeePasswordChange}
+              inputMode="numeric"
+              autoComplete="off"
+              isError={isAttendeePasswordError}
+            />
+            <Field.ErrorMessage
+              errorMessage={attendeeNameErrorMessage || attendeePasswordErrorMessage}
+            />
+          </Field>
+        </div>
+        <Button
+          variant="primary"
+          size="full"
+          onClick={handleLoginButtonClick}
+          disabled={!isFormValid()}
+        >
+          {MEETING_BUTTON_TEXTS.register}
+        </Button>
       </div>
-      <Button
-        variant="primary"
-        size="full"
-        onClick={handleLoginButtonClick}
-        disabled={!isFormValid()}
-      >
-        로그인
-      </Button>
-    </div>
+    </ScrollBlock>
   );
 }

--- a/frontend/src/pages/CreateMeetingPage/components/MeetingDateTime/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingDateTime/index.tsx
@@ -14,7 +14,8 @@ import type useDateSelect from '@hooks/useDateSelect/useDateSelect';
 import type useMeetingType from '@hooks/useMeetingType/useMeetingType';
 import type { UseTimeRangeDropdownReturn } from '@hooks/useTimeRangeDropdown/useTimeRangeDropdown';
 
-import { FIELD_DESCRIPTIONS } from '@constants/inputFields';
+import { MEETING_BUTTON_TEXTS } from '@constants/button';
+import { FIELD_DESCRIPTIONS, FIELD_LABELS, FIELD_TITLES } from '@constants/inputFields';
 
 import { s_container, s_dateCandidateSelector } from './MeetingDateTime.styles';
 
@@ -74,7 +75,7 @@ export default function MeetingDateTime({
     <div css={s_container}>
       <div css={s_dateCandidateSelector}>
         <Field>
-          <Field.Label id="날짜선택" labelText="약속 후보 날짜 선택" />
+          <Field.Title title={FIELD_TITLES.meetingDateTime} />
           <Field.Description description={FIELD_DESCRIPTIONS.date} />
           <Calendar>
             <Calendar.Header
@@ -107,13 +108,13 @@ export default function MeetingDateTime({
           onChange={handleToggleIsChecked}
           id="meetingType"
           isChecked={isChecked}
-          labelText="날짜만 선택할래요"
+          labelText={FIELD_LABELS.onlyDate}
         />
       </div>
 
       {!isChecked && (
         <Field>
-          <Field.Label id="약속시간범위선택" labelText="약속 시간 범위 선택" />
+          <Field.Title title={FIELD_TITLES.meetingTimeRange} />
           <TimeRangeSelector
             startTime={startTime}
             endTime={endTime}
@@ -124,7 +125,7 @@ export default function MeetingDateTime({
       )}
 
       <BottomFixedButton onClick={onMeetingCreateButtonClick} disabled={isCreateMeetingFormInvalid}>
-        약속 생성하기
+        {MEETING_BUTTON_TEXTS.create}
       </BottomFixedButton>
     </div>
   );

--- a/frontend/src/pages/CreateMeetingPage/components/MeetingHostInfo/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingHostInfo/index.tsx
@@ -1,11 +1,13 @@
+import ScrollBlock from '@components/ScrollBlock';
 import BottomFixedButton from '@components/_common/Buttons/BottomFixedButton';
 import Field from '@components/_common/Field';
-import Input from '@components/_common/Input';
+import Text from '@components/_common/Text';
 
 import useButtonOnKeyboard from '@hooks/useButtonOnKeyboard/useButtonOnKeyboard';
 import type { UseInputReturn } from '@hooks/useInput/useInput';
 
-import { FIELD_DESCRIPTIONS } from '@constants/inputFields';
+import { MEETING_BUTTON_TEXTS } from '@constants/button';
+import { FIELD_LABELS, FIELD_PLACEHOLDERS, FIELD_TITLES } from '@constants/inputFields';
 
 interface MeetingHostInfoProps {
   hostNickNameInput: UseInputReturn;
@@ -32,36 +34,45 @@ export default function MeetingHostInfo({
   } = hostPasswordInput;
 
   const resizedButtonHeight = useButtonOnKeyboard();
+  const isHostNickNameError = hostNickNameErrorMessage !== null;
+  const isHostPasswordError = hostPasswordErrorMessage !== null;
 
   return (
-    <>
+    <ScrollBlock>
       <Field>
-        <Field.Label id="닉네임" labelText="닉네임" />
-        <Field.Description description={FIELD_DESCRIPTIONS.nickname} />
-        <Input id="닉네임" value={hostNickName} onChange={handleHostNickNameChange} autoFocus />
-        <Field.ErrorMessage errorMessage={hostNickNameErrorMessage} />
-      </Field>
-
-      <Field>
-        <Field.Label id="비밀번호" labelText="비밀번호" />
-        <Field.Description description={FIELD_DESCRIPTIONS.password} />
-        <Input
-          type="number"
-          id="비밀번호"
-          inputMode="numeric"
-          pattern="[0-9]*"
+        <Field.Title title={FIELD_TITLES.meetingHostInfo} />
+        <Text typo="captionBold" variant="caption">
+          약속을 생성하면
+          <Text.Accent text=" 자동으로 로그인"></Text.Accent>
+          돼요
+        </Text>
+        <Field.FloatingInput
+          label={FIELD_LABELS.nickname}
+          placeholder={FIELD_PLACEHOLDERS.nickname}
+          value={hostNickName}
+          onChange={handleHostNickNameChange}
+          autoComplete="off"
+          isError={isHostNickNameError}
+          autoFocus
+        />
+        <Field.FloatingInput
+          label={FIELD_LABELS.password}
+          placeholder={FIELD_PLACEHOLDERS.password}
           value={hostPassword}
           onChange={handleHostPasswordChange}
+          autoComplete="off"
+          isError={isHostPasswordError}
+          inputMode="numeric"
         />
-        <Field.ErrorMessage errorMessage={hostPasswordErrorMessage} />
+        <Field.ErrorMessage errorMessage={hostNickNameErrorMessage || hostPasswordErrorMessage} />
       </Field>
       <BottomFixedButton
         onClick={onNextStep}
         disabled={isHostInfoInvalid}
         height={resizedButtonHeight}
       >
-        다음
+        {MEETING_BUTTON_TEXTS.next}
       </BottomFixedButton>
-    </>
+    </ScrollBlock>
   );
 }

--- a/frontend/src/pages/CreateMeetingPage/components/MeetingName/index.tsx
+++ b/frontend/src/pages/CreateMeetingPage/components/MeetingName/index.tsx
@@ -1,11 +1,12 @@
+import ScrollBlock from '@components/ScrollBlock';
 import BottomFixedButton from '@components/_common/Buttons/BottomFixedButton';
 import Field from '@components/_common/Field';
-import Input from '@components/_common/Input';
 
 import useButtonOnKeyboard from '@hooks/useButtonOnKeyboard/useButtonOnKeyboard';
 import type { UseInputReturn } from '@hooks/useInput/useInput';
 
-import { FIELD_DESCRIPTIONS } from '@constants/inputFields';
+import { MEETING_BUTTON_TEXTS } from '@constants/button';
+import { FIELD_LABELS, FIELD_PLACEHOLDERS, FIELD_TITLES } from '@constants/inputFields';
 
 interface MeetingNameProps {
   meetingNameInput: UseInputReturn;
@@ -24,18 +25,20 @@ export default function MeetingName({
     errorMessage: meetingNameErrorMessage,
   } = meetingNameInput;
 
+  const isTextError = meetingNameErrorMessage !== null;
   const resizedButtonHeight = useButtonOnKeyboard();
 
   return (
-    <>
+    <ScrollBlock>
       <Field>
-        <Field.Label id="약속이름" labelText="약속 이름" />
-        <Field.Description description={FIELD_DESCRIPTIONS.meetingName} />
-        <Input
-          id="약속이름"
+        <Field.Title title={FIELD_TITLES.meetingName} />
+        <Field.FloatingInput
+          label={FIELD_LABELS.meetingName}
+          placeholder={FIELD_PLACEHOLDERS.nickname}
           value={meetingName}
           onChange={handleMeetingNameChange}
           autoComplete="off"
+          isError={isTextError}
           autoFocus
         />
         <Field.ErrorMessage errorMessage={meetingNameErrorMessage} />
@@ -45,8 +48,8 @@ export default function MeetingName({
         disabled={isMeetingNameInvalid}
         height={resizedButtonHeight}
       >
-        다음
+        {MEETING_BUTTON_TEXTS.next}
       </BottomFixedButton>
-    </>
+    </ScrollBlock>
   );
 }

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -162,8 +162,13 @@ const globalStyles = css`
 
   button {
     cursor: pointer;
+
     padding: 0;
+
     font: inherit;
+    color: inherit;
+
+    appearance: none; /* IOS 디바이스의 버튼 색상이 파란색으로 보이는 문제 해결(@해리) */
     border: none;
   }
 `;


### PR DESCRIPTION
## 관련 이슈

- resolves: #410 

## 작업 내용

### 인풋 컴포넌트 디자인 개선

모바일 기기에서는 입력을 하기 위해 가상 키패드가 올라옵니다. 이 때, 가상 키패드 뒤에 가상 영역이 생기는 문제가 있어, 스크롤이 되는데요. 사용자 경험 향상을 위해서 퍼널 패턴을 도입했지만, 아이러니하게도 다시 사용자 경험을 저하시키는 요소가 발견되었습니다. 따라서, 이 문제를 해결하기 위해서 브레인 스토밍을 했었죠!

<img width="740" alt="image" src="https://github.com/user-attachments/assets/f3d99452-e4fe-40a6-8e42-a9f8afd1d8fd">
<br/>
해당 이미지처럼 닉네임, 비밀번호를 가로로 배치하거나, 닉네임과 비밀번호 입력 스텝을 구분하는 방법이 제시되었는데 

- 가로로 배치하는 것은 이미 작은 모바일 기기에 어울리지 않는다는 점
- 닉네임과 비밀번호를 따로 입력하는 것은 입력 관심사를 퍼널 패턴을 도입하기 위해 억지로 분리한다는 점

이 두 가지 생각으로 인해서 채택되지 않았습니다. 결국 스크롤을 막기 위해서 선택한 방법은 **인풋 필드의 높이를 줄이는 것**이었습니다. 

| Before | After |
|--------|-------|
| ![Before Image](https://github.com/user-attachments/assets/66f44ca7-29f1-420f-9732-e367dd0e4cd4) | ![After Image](https://github.com/user-attachments/assets/56912274-5389-4858-8495-1447a3ddecf9) |

인풋 필드의 높이를 줄이고, 헤더의 높이도 줄이면 모바일 기기에서 현재 포커스되는 인풋 필드로 강제로 스크롤 하는 문제는 어느정도 해결되었습니다. 아이폰 7 사용자는 약간의 스크롤은 발생하기는 하지만, 이전 상황에 비하면 훨씬 개선되었다고 판단했어요.

### ScrollBlock.tsx

해당 컴포넌트는 children이 모바일 환경에서 스크롤되지 않도록 하는 책임을 가집니다. 

```tsx
useEffect(() => {
  const handleTouchMove = (e: TouchEvent) => {
    e.preventDefault();
  };

  // 터치 이벤트를 사용해서 스크롤을 할 경우, 해당 스크롤을 막는다는 것을 브라우저에게 명시적으로 알려주기 위해서 passive 속성 추가(@해리)
  document.addEventListener('touchmove', handleTouchMove, { passive: false });

  return () => {
    document.removeEventListener('touchmove', handleTouchMove);
  };
}, []);
```
`{passive: false}`를 설정이 왜 필요했는지에 대해서 설명드릴게요. 모바일에서 브라우저는 터치 이벤트가 발생할 때, 성능 최적화를 위해서 기본적으로 true로 설정합니다. 마우스나, 손가락을 이용해서 특정 페이지를 스크롤 할 때, 브라우저는 빠르게 이벤트에 반응해서 스크롤을 해줘야 하는 책임을 가지고 있습니다. 이 때, passive 속성은 e.preventDefault()를 실행할지 말지 암묵적으로 결정하는 속성입니다.

1. true

true인 경우, 브라우저는 이벤트 핸들러가 `e.preventDefault()`를 호출하지 않을 것으로 보장받습니다. 그러므로, 이벤트 핸들러가 실행되기 전 우선적으로 스크롤을 처리하게 됩니다. 이것이 스크롤 성능 최적화입니다. 자세한 내용은 [MDN의 스크롤 성능 향상 섹션](https://developer.mozilla.org/ko/docs/Web/API/EventTarget/addEventListener#%ED%8C%A8%EC%8B%9C%EB%B8%8C_%EC%88%98%EC%8B%A0%EA%B8%B0%EB%A1%9C_%EC%8A%A4%ED%81%AC%EB%A1%A4_%EC%84%B1%EB%8A%A5_%ED%96%A5%EC%83%81)에서 확인할 수 있어요. 

2. false

false인 경우에는, 브라우저가 이벤트 핸들러 내부에서 `e.preventDefault()`를 호출할지 모른다고 가정합니다. 따라서, 내부에서 해당 메서드를 호출할 수 있기 때문에 스크롤을 바로 실행하지 않고 이벤트 핸들러가 완료될 때까지 기다립니다. 이 기다림이 메인 스레드를 블록하고, 렌더링 지연으로 이어집니다.

브라우저는 스크롤 관련 성능 최적화를 위해서, `touchmove`, `wheel`과 같은 이벤트의 passive를 기본적으로 true로 설정합니다. 하지만, 저희는 스크롤을 막기로 결정했기 때문에, false속성과 함께 기본 동작인 스크롤을 막을 수 있도록 e.preventDefault()함수를 호출했습니다!

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
