### PR TITLE
[FE] 달력 확정 페이지 ConfirmModal 추가 및 로그인 후 라우팅 경로 수정

### DIFF
--- a/frontend/src/stores/servers/user/mutations.ts
+++ b/frontend/src/stores/servers/user/mutations.ts
@@ -22,7 +22,7 @@ export const usePostLoginMutation = () => {
 
       setIsLoggedIn(true);
       setUserName(userName);
-      routeTo(`/meeting/${uuid}`);
+      routeTo(`/meeting/${uuid}/register`);
     },
   });
 };


### PR DESCRIPTION
## 관련 이슈

- resolves: #425 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

- 로그인 시 라우팅 경로 `/meeting/:uuid` -> `/meeting/:uuid/register`로 변경
- ConfirmModal 날짜만 선택 옵션 사용 시에도 동작하도록 수정


https://github.com/user-attachments/assets/249775de-2219-4487-bc9f-537f4d4acdd7


<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

없습니다~!

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
