### PR TITLE
[FE] 달력 확정 페이지에서도 약속 잠금 모달을 사용할 수 있도록 수정

### DIFF
--- a/frontend/src/stores/servers/user/mutations.ts
+++ b/frontend/src/stores/servers/user/mutations.ts
@@ -22,7 +22,7 @@ export const usePostLoginMutation = () => {
 
       setIsLoggedIn(true);
       setUserName(userName);
-      routeTo(`/meeting/${uuid}`);
+      routeTo(`/meeting/${uuid}/register`);
     },
   });
 };


### PR DESCRIPTION
* refactor: 로그인 시, 등록 페이지로 이동하도록 라우팅 경로 수정

* feat: 날짜만 조회 선택 후 확정 페이지 이동 시 ConfirmModal을 띄우도록 추가

## 관련 이슈

- resolves: #426 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
