### PR TITLE
[BE] 일정 등록 API 데드락 문제 해결

### DIFF
--- a/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/kr/momo/service/schedule/ScheduleService.java
@@ -31,6 +31,7 @@ import kr.momo.service.schedule.recommend.ScheduleRecommender;
 import kr.momo.service.schedule.recommend.ScheduleRecommenderFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -44,7 +45,7 @@ public class ScheduleService {
     private final ScheduleBatchRepository scheduleBatchRepository;
     private final ScheduleRecommenderFactory scheduleRecommenderFactory;
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void create(String uuid, long attendeeId, ScheduleCreateRequest request) {
         Meeting meeting = meetingRepository.findByUuid(uuid)
                 .orElseThrow(() -> new MomoException(MeetingErrorCode.INVALID_UUID));


### PR DESCRIPTION
## 관련 이슈

- resolves: #438 

## 작업 내용

<!-- 해당 PR에서 작업한 내용을 간략히 설명해 주세요. (이미지 첨부 가능) -->

<!-- 코드가 아닌 기능 단위로 설명을 작성하며, 기능이 여러 개인 경우 각각을 잘 구분하여 설명해 주세요. -->

일정 등록 API에서 발생하는 데드락 문제를 해결하였습니다.
문제 인식부터 해결 과정까지 전부 문서화하였습니다.
내용이 너무 길어 문서 링크를 대신 첨부합니다.

[데드락 핸들링 (MySQL Gap Lock) Notion](https://harvest-skirt-b55.notion.site/MySQL-Gap-Lock-12941318783f802688bae3dfe33a5ee8?pvs=4)

- 실패한 트랜잭션 재발행
- 트랜잭션 격리 수준 변경

제가 고려한 해결 방안은 위 두가지이고, 격리 수준을 `READ COMMITTED` 로 변경하는 방법을 선택했습니다.
더 좋은 해결 방법이 있으면 공유 부탁드립니다 😀

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->

## 리뷰 요구사항 (선택)

<!-- 리뷰 중점 사항: 리뷰어가 특히 집중해서 봐야 할 부분이 있나요? -->

<!-- 추가 검토 사항: 코드, 디자인, 구현 방식 등에 대한 추가적인 검토가 필요한 사항이 있나요? -->

<!-- 논의가 필요한 부분: 코드 리뷰 중 논의가 필요해 보이는 부분은 무엇인가요? -->
