### PR TITLE
[FE] 프론트엔드 CD 파이프라인 업데이트

### DIFF
--- a/.github/workflows/frontend-dev-cd.yml
+++ b/.github/workflows/frontend-dev-cd.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: 이전 의존성을 저장해둔게 있나~? 확인해요 :)
+      - name: 의존성 캐시를 확인해요 :)
         id: cache
         uses: actions/cache@v4
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: 프론트엔드 리소스를 빌드해요 :)
         run: npm run build:dev
 
-      - name: 프론트엔드 리소스 결과물을 깃허브 레파지토리 artifacts로 업로드해요
+      - name: 프론트엔드 리소스 결과물을 깃허브 레파지토리 artifacts로 업로드해요 :)
         uses: actions/upload-artifact@v4
         with:
           name: momoResources
@@ -76,23 +76,19 @@ jobs:
 
   deploy:
     needs: fe-build
-    runs-on: [self-hosted, linux, ARM64, dev]
+    runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_DISTRIBUTION_ID_DEV: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV}}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CLOUDFRONT_DISTRIBUTION_ID_DEV: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}
     steps:
-      - name: 기존 dist 폴더 내부에 있던 이전 버젼의 dist 폴더 내부 모든 파일을 삭제해요
-        working-directory: ./frontend/
-        run: |
-          rm -rf dist/*
-
-      - name: 모모 깃허브 레파지토리 artifacts로 부터 빌드 결과물을 다운받아요 :)
+      - name: 모모 깃허브 레파지토리 artifacts로부터 빌드 결과물을 다운받아요 :)
         uses: actions/download-artifact@v4
         with:
           name: momoResources
           path: ./frontend/dist
 
-      - name: aws에 배포하고 cloudfront 캐싱을 무효화해요
-        working-directory: ./frontend/dist/
+      - name: aws에 배포하고 cloudfront 캐싱을 무효화해요 :)
         run: |
-          aws s3 sync ./ s3://techcourse-project-2024/momo-dev --delete
+          aws s3 sync ./frontend/dist/ s3://momo-fe-s3/momo-fe-dev/ --delete
           aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID_DEV" --paths "/*"

--- a/.github/workflows/frontend-prod-cd.yml
+++ b/.github/workflows/frontend-prod-cd.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # 모든 히스토리를 가져옵니다
-      - name: Get previous tag
+          fetch-depth: 0 # 모든 히스토리를 가져오기
+      - name: 이전 태그를 가져와요 :)
         id: previoustag
         run: echo "PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ --always)" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v3
@@ -33,8 +33,9 @@ jobs:
               - 'backend/**'
             frontend:
               - 'frontend/**'
+
   fe-build:
-    needs: detect-changes # jobs들은 병렬로 실행됨, needs 키워드를 사용해서 특정 job이 완료(성공)면 실행하도록 설정
+    needs: detect-changes
     if: ${{ needs.detect-changes.outputs.frontend == 'true' }}
     runs-on: ubuntu-latest
     defaults:
@@ -46,12 +47,12 @@ jobs:
       - name: 모모 레파지토리의 코드를 가져와요 :)
         uses: actions/checkout@v4
 
-      - name: 노드 버젼을 설정해요 :)
+      - name: 노드 버전을 설정해요 :)
         uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
 
-      - name: 이전 의존성을 저장해둔게 있나~? 확인해요 :)
+      - name: 의존성 캐시를 확인해요 :)
         id: cache
         uses: actions/cache@v4
         with:
@@ -72,7 +73,7 @@ jobs:
       - name: 프론트엔드 리소스를 빌드해요 :)
         run: npm run build:prod
 
-      - name: 프론트엔드 리소스 결과물을 깃허브 레파지토리 artifacts로 업로드해요
+      - name: 프론트엔드 리소스 결과물을 깃허브 레파지토리 artifacts로 업로드해요 :)
         uses: actions/upload-artifact@v4
         with:
           name: momoResources
@@ -80,23 +81,19 @@ jobs:
 
   deploy:
     needs: fe-build
-    runs-on: [self-hosted, linux, ARM64, dev]
+    runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_DISTRIBUTION_ID_PROD: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD}}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CLOUDFRONT_DISTRIBUTION_ID_PROD: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}
     steps:
-      - name: 기존 dist 폴더 내부에 있던 이전 버젼의 dist 폴더 내부 모든 파일을 삭제해요
-        working-directory: ./frontend/
-        run: |
-          rm -rf dist/*
-
-      - name: 모모 깃허브 레파지토리 artifacts로 부터 빌드 결과물을 다운받아요 :)
+      - name: 모모 깃허브 레파지토리 artifacts로부터 빌드 결과물을 다운받아요 :)
         uses: actions/download-artifact@v4
         with:
           name: momoResources
           path: ./frontend/dist
 
-      - name: aws에 배포하고 cloudfront 캐싱을 무효화해요
-        working-directory: ./frontend/dist/
+      - name: aws에 배포하고 cloudfront 캐싱을 무효화해요 :)
         run: |
-          aws s3 sync ./ s3://techcourse-project-2024/momo --delete
+          aws s3 sync ./frontend/dist/ s3://momo-fe-s3/momo-fe-prod/ --delete
           aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID_PROD" --paths "/*"


### PR DESCRIPTION
## 관련 이슈
- resolves: #450

## 작업 내용  
기존 우아한테크코스 AWS 계정에서 MOMO 자체 AWS 계정으로 전환함에 따라 프론트엔드 dev 및 prod 배포 파이프라인을 업데이트했습니다.  

### 주요 변경 사항
1. **AWS 계정 변경**
   - S3 버킷 및 CloudFront 배포 ID를 MOMO의 AWS 계정으로 변경  
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` 추가하여 AWS 인증 방식 적용  

2. **배포 방식 개선**
   - `runs-on: [self-hosted, linux, ARM64, dev]` → `runs-on: ubuntu-latest` 변경하여 배포 환경 통일  
   - 배포 대상 S3 버킷 경로 변경
     - `s3://techcourse-project-2024/momo-dev` → `s3://momo-fe-s3/momo-fe-dev/`  
     - `s3://techcourse-project-2024/momo` → `s3://momo-fe-s3/momo-fe-prod/`  

3. **IAM 권한 문제 해결**  
   - 배포 과정에서 IAM 사용자(`momo-fe`)가 S3 버킷(`momo-fe-s3`)에서 `s3:ListBucket` 작업을 수행할 권한이 없어 오류 발생 → 아래의 정책을 적용하여 배포 시 S3 버킷 접근 권한 문제 해결
     ```json
     {
       "Action": [
         "s3:ListBucket",
         "s3:PutObject",
         "s3:GetObject",
         "s3:DeleteObject"
       ],
       "Effect": "Allow",
       "Resource": "arn:aws:s3:::<버킷명>"
     }
     ```  

4. **배포 워크플로우 테스트**
   - 검증을 위해 MOMO의 main 레포지토리를 fork하여 [개인 레포지토리](https://github.com/Yoonkyoungme/practice-momo-cicd)에서 배포 테스트 진행
   - 업데이트된 CD 워크플로우의 정상 동작을 검증하기 위해 build된 정적 파일이 momo-fe-s3 S3 버킷의 test 경로에 업로드되는지 확인하였습니다. 이후 CloudFront 캐시를 무효화하여 변경 사항이 정상적으로 반영되는지 검증하였습니다. (https://test.momonow.kr)

      | dev CD 동작 확인 | prod CD 동작 확인 |
      |-----------------|------------------|
      | ![image](https://github.com/user-attachments/assets/5ea65b85-a7ec-4f9b-854a-3e2fb180b673) | ![image](https://github.com/user-attachments/assets/81a67cd7-eb76-4af6-8160-24707d8691d3) |



## 특이 사항  


## 리뷰 요청 사항 (선택)